### PR TITLE
Don't switch CUDA devices when deleting MemoryResources and DeviceBuffers

### DIFF
--- a/modules/rmm/src/device_buffer.cpp
+++ b/modules/rmm/src/device_buffer.cpp
@@ -97,11 +97,7 @@ DeviceBuffer::DeviceBuffer(CallbackArgs const& args) : Napi::ObjectWrap<DeviceBu
 }
 
 void DeviceBuffer::Finalize(Napi::Env env) {
-  if (buffer_.get() != nullptr && !mr_.IsEmpty()) {
-    if (size() > 0) { Napi::MemoryManagement::AdjustExternalMemory(env, -size()); }
-    Device::call_in_context(device(), [&]() { buffer_.reset(nullptr); });
-    mr_.Reset();
-  }
+  Napi::MemoryManagement::AdjustExternalMemory(env, -size());
 }
 
 Napi::Value DeviceBuffer::byte_length(Napi::CallbackInfo const& info) {

--- a/modules/rmm/src/memory_resouce.cpp
+++ b/modules/rmm/src/memory_resouce.cpp
@@ -102,10 +102,6 @@ CudaMemoryResource::CudaMemoryResource(CallbackArgs const& args)
   }
 }
 
-void CudaMemoryResource::Finalize(Napi::Env env) {
-  Device::call_in_context(device_id_, [&]() { mr_.reset(); });
-}
-
 // ManagedMemoryResource
 
 Napi::FunctionReference ManagedMemoryResource::constructor;
@@ -134,10 +130,6 @@ ManagedMemoryResource::ManagedMemoryResource(CallbackArgs const& args)
   : Napi::ObjectWrap<ManagedMemoryResource>(args) {
   device_id_ = Device::active_device_id();
   mr_.reset(new rmm::mr::managed_memory_resource());
-}
-
-void ManagedMemoryResource::Finalize(Napi::Env env) {
-  Device::call_in_context(device_id_, [&]() { mr_.reset(); });
 }
 
 // PoolMemoryResource
@@ -182,10 +174,6 @@ PoolMemoryResource::PoolMemoryResource(CallbackArgs const& args)
     maximum_pool_size == -1 ? thrust::nullopt : thrust::make_optional(maximum_pool_size)));
 
   upstream_mr_.Reset(args[0], 1);
-}
-
-void PoolMemoryResource::Finalize(Napi::Env env) {
-  Device::call_in_context(device(), [&]() { mr_.reset(); });
 }
 
 int32_t PoolMemoryResource::device() const {
@@ -242,10 +230,6 @@ FixedSizeMemoryResource::FixedSizeMemoryResource(CallbackArgs const& args)
   upstream_mr_.Reset(args[0], 1);
 }
 
-void FixedSizeMemoryResource::Finalize(Napi::Env env) {
-  Device::call_in_context(device(), [&]() { mr_.reset(); });
-}
-
 int32_t FixedSizeMemoryResource::device() const {
   return NapiToCPP(upstream_mr_.Value()).operator rmm::cuda_device_id().value();
 }
@@ -300,10 +284,6 @@ BinningMemoryResource::BinningMemoryResource(CallbackArgs const& args)
                   mr, min_size_exponent, max_size_exponent));
 
   upstream_mr_.Reset(args[0], 1);
-}
-
-void BinningMemoryResource::Finalize(Napi::Env env) {
-  Device::call_in_context(device(), [&]() { mr_.reset(); });
 }
 
 int32_t BinningMemoryResource::device() const {
@@ -392,10 +372,6 @@ LoggingResourceAdapter::LoggingResourceAdapter(CallbackArgs const& args)
     args[0], log_file_path_, auto_flush));
 
   upstream_mr_.Reset(args[0], 1);
-}
-
-void LoggingResourceAdapter::Finalize(Napi::Env env) {
-  Device::call_in_context(device(), [&]() { mr_.reset(); });
 }
 
 int32_t LoggingResourceAdapter::device() const {

--- a/modules/rmm/src/node_rmm/memory_resource.hpp
+++ b/modules/rmm/src/node_rmm/memory_resource.hpp
@@ -108,14 +108,6 @@ class CudaMemoryResource : public Napi::ObjectWrap<CudaMemoryResource>, public M
   CudaMemoryResource(CallbackArgs const& args);
 
   /**
-   * @brief Destructor called when the JavaScript VM garbage collects this CudaMemoryResource
-   * instance.
-   *
-   * @param env The active JavaScript environment.
-   */
-  void Finalize(Napi::Env env) override;
-
-  /**
    * @brief Check whether an Napi value is an instance of `CudaMemoryResource`.
    *
    * @param val The Napi::Value to test
@@ -153,14 +145,6 @@ class ManagedMemoryResource : public Napi::ObjectWrap<ManagedMemoryResource>,
   ManagedMemoryResource(CallbackArgs const& args);
 
   /**
-   * @brief Destructor called when the JavaScript VM garbage collects this ManagedMemoryResource
-   * instance.
-   *
-   * @param env The active JavaScript environment.
-   */
-  void Finalize(Napi::Env env) override;
-
-  /**
    * @brief Check whether an Napi value is an instance of `ManagedMemoryResource`.
    *
    * @param val The Napi::Value to test
@@ -195,14 +179,6 @@ class PoolMemoryResource : public Napi::ObjectWrap<PoolMemoryResource>, public M
    *
    */
   PoolMemoryResource(CallbackArgs const& args);
-
-  /**
-   * @brief Destructor called when the JavaScript VM garbage collects this PoolMemoryResource
-   * instance.
-   *
-   * @param env The active JavaScript environment.
-   */
-  void Finalize(Napi::Env env) override;
 
   /**
    * @brief Check whether an Napi value is an instance of `PoolMemoryResource`.
@@ -245,14 +221,6 @@ class FixedSizeMemoryResource : public Napi::ObjectWrap<FixedSizeMemoryResource>
   FixedSizeMemoryResource(CallbackArgs const& args);
 
   /**
-   * @brief Destructor called when the JavaScript VM garbage collects this FixedSizeMemoryResource
-   * instance.
-   *
-   * @param env The active JavaScript environment.
-   */
-  void Finalize(Napi::Env env) override;
-
-  /**
    * @brief Check whether an Napi value is an instance of `FixedSizeMemoryResource`.
    *
    * @param val The Napi::Value to test
@@ -291,14 +259,6 @@ class BinningMemoryResource : public Napi::ObjectWrap<BinningMemoryResource>,
    *
    */
   BinningMemoryResource(CallbackArgs const& args);
-
-  /**
-   * @brief Destructor called when the JavaScript VM garbage collects this BinningMemoryResource
-   * instance.
-   *
-   * @param env The active JavaScript environment.
-   */
-  void Finalize(Napi::Env env) override;
 
   /**
    * @brief Check whether an Napi value is an instance of `BinningMemoryResource`.
@@ -362,14 +322,6 @@ class LoggingResourceAdapter : public Napi::ObjectWrap<LoggingResourceAdapter>,
    *
    */
   LoggingResourceAdapter(CallbackArgs const& args);
-
-  /**
-   * @brief Destructor called when the JavaScript VM garbage collects this LoggingResourceAdapter
-   * instance.
-   *
-   * @param env The active JavaScript environment.
-   */
-  void Finalize(Napi::Env env) override;
 
   /**
    * @brief Check whether an Napi value is an instance of `LoggingResourceAdapter`.


### PR DESCRIPTION
I was being paranoid about ensuring the allocation device was made current when deleting `device_buffers` and `memory_resources`. Upon further testing, it doesn't look like this is required.