### PR TITLE
Use rapidsai/rmm repo again

### DIFF
--- a/modules/core/cmake/Modules/ConfigureRMM.cmake
+++ b/modules/core/cmake/Modules/ConfigureRMM.cmake
@@ -20,12 +20,8 @@ function(find_and_configure_rmm VERSION)
 
     CPMAddPackage(NAME rmm
         VERSION        ${RMM_VERSION}
-        # GIT_REPOSITORY https://github.com/rapidsai/rmm.git
-        # GIT_TAG        branch-${RMM_VERSION}
-        GIT_REPOSITORY  https://github.com/trxcllnt/rmm.git
-        # Can also use a local path to your repo clone for testing
-        # GIT_REPOSITORY /home/ptaylor/dev/rapids/rmm
-        GIT_TAG        fix/rmm-cmake-version
+        GIT_REPOSITORY https://github.com/rapidsai/rmm.git
+        GIT_TAG        branch-${RMM_VERSION}
         GIT_SHALLOW    TRUE
         OPTIONS        "BUILD_TESTS OFF"
                        "BUILD_BENCHMARKS OFF"


### PR DESCRIPTION
Now that RMM has merged our version bump, we can use it again.