### PR TITLE
Remove special linker flags for cudf target

### DIFF
--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -67,4 +67,4 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
 target_link_libraries(${PROJECT_NAME}
                       ${CMAKE_JS_LIB}
                       rmm::rmm
-                      ${CUDF_LIBRARY})
+                      cudf::cudf)

--- a/modules/core/cmake/Modules/ConfigureCUDF.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUDF.cmake
@@ -43,10 +43,6 @@ function(find_and_configure_cudf VERSION)
                         "CUDA_STATIC_RUNTIME ON"
                         "AUTO_DETECT_CUDA_ARCHITECTURES ON"
                         "DISABLE_DEPRECATION_WARNING ${DISABLE_DEPRECATION_WARNINGS}")
-
-    # Because libcudf.so doesn't contain any symbols, the linker will determine
-    # that it's okay to prune it before copying `DT_NEEDED` entries from it.
-    set(CUDF_LIBRARY "-Wl,--no-as-needed" cudf::cudf "-Wl,--as-needed" PARENT_SCOPE)
 endfunction()
 
 find_and_configure_cudf(${CUDF_VERSION})

--- a/modules/cudf/CMakeLists.txt
+++ b/modules/cudf/CMakeLists.txt
@@ -78,6 +78,6 @@ target_link_libraries(${PROJECT_NAME}
                       ${CMAKE_JS_LIB}
                       ${Boost_LIBRARIES}
                       rmm::rmm
-                      ${CUDF_LIBRARY}
+                      cudf::cudf
                       "${NVIDIA_RMM_MODULE_PATH}/build/${CMAKE_BUILD_TYPE}/node_rmm.node"
                       "${NVIDIA_CUDA_MODULE_PATH}/build/${CMAKE_BUILD_TYPE}/node_cuda.node")

--- a/modules/cugraph/CMakeLists.txt
+++ b/modules/cugraph/CMakeLists.txt
@@ -102,7 +102,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
 target_link_libraries(${PROJECT_NAME}
                       ${CMAKE_JS_LIB}
                       rmm::rmm
-                      ${CUDF_LIBRARY}
+                      cudf::cudf
                       CUDA::cuda_driver
                       CUDA::cudart_static
                       "${NVIDIA_RMM_MODULE_PATH}/build/${CMAKE_BUILD_TYPE}/node_rmm.node"


### PR DESCRIPTION
We were able to remove the need for these linker flags in [cudf/pull/7107](https://github.com/rapidsai/cudf/pull/7107).