### PR TITLE
Don't store explicit Table property

### DIFF
--- a/modules/cudf/src/column_accessor.ts
+++ b/modules/cudf/src/column_accessor.ts
@@ -20,6 +20,13 @@ export class ColumnAccessor<T extends TypeMap = any> {
   private _labels_to_indices: Map<keyof T, number> = new Map();
 
   constructor(data: ColumnsMap<T>) {
+    const columns = Object.values(data);
+    if (columns.length > 0) {
+      const N = columns[0].length;
+      if (!columns.every((col) => col.length == N)) {
+        throw new Error("Column lengths must all be the same")
+      }
+    }
     this._data = data;
     this.names.forEach((val, index) => this._labels_to_indices.set(val, index));
   }

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Series, Table} from '@nvidia/cudf';
+import {Series} from '@nvidia/cudf';
 
 import {ColumnAccessor} from './column_accessor'
 import {ColumnsMap, TypeMap} from './types'
@@ -40,15 +40,9 @@ export class DataFrame<T extends TypeMap = any> {
     }
   }
 
-  get numRows() {
-    const table = new Table({columns: this._accessor.columns});
-    return table.numRows;
-  }
+  get numRows() { return this._accessor.columns[0].length; }
 
-  get numColumns() {
-    const table = new Table({columns: this._accessor.columns});
-    return table.numColumns;
-  }
+  get numColumns() { return this._accessor.length; }
 
   get names() { return this._accessor.names; }
 


### PR DESCRIPTION
Small PR, computes `Table` as needed, rather than storing on `DataFrame` 