### PR TITLE
Make dockerfiles work on both amd64 and arm64v8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,31 +8,36 @@ x-common-service-settings: &common_service_settings
   network_mode: "host"
   working_dir: "${PWD}"
   user: "${UID:-1000}:${GID:-1000}"
+  build: &common_build_settings
+    context: .
+    args: &common_build_args
+      UID: ${UID:-1000}
+      GID: ${GID:-1000}
+      NODE_VERSION: "${NODE_VERSION:-14.10.1}"
+      YARN_VERSION: "${YARN_VERSION:-1.22.5}"
+      PARALLEL_LEVEL: "${PARALLEL_LEVEL:-}"
+      CMAKE_VERSION: "${CMAKE_VERSION:-3.18.5}"
+      CCACHE_VERSION: "${CCACHE_VERSION:-4.1}"
+  environment: &common_environment_variables
+    # Colorize the terminal in the container if possible
+    TERM: "${TERM:-}"
+    # Use the host's X11 display
+    DISPLAY: "${DISPLAY:-}"
+    XAUTHORITY: "${XAUTHORITY:-}"
+    XDG_SESSION_TYPE: "${XDG_SESSION_TYPE:-}"
+    NVIDIA_DRIVER_CAPABILITIES: "all"
 
 services:
 
   runtime:
     <<: *common_service_settings
-    image: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.0}-runtime-${LINUX_VERSION:-ubuntu18.04}
-    build: &runtime_build_settings
+    image: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.0}-runtime-${LINUX_VERSION:-ubuntu18.04}-amd64
+    build:
+      <<: *common_build_settings
       dockerfile: dockerfiles/runtime.Dockerfile
-      context: .
       args:
-        UID: ${UID:-1000}
-        GID: ${GID:-1000}
-        PARALLEL_LEVEL: "${PARALLEL_LEVEL:-}"
-        CUDA_VERSION: "${CUDA_VERSION:-11.0}"
-        NODE_VERSION: "${NODE_VERSION:-14.10.1}"
-        RAPIDS_VERSION: "${RAPIDS_VERSION:-latest}"
-        LINUX_VERSION: "${LINUX_VERSION:-ubuntu18.04}"
-    environment: &runtime_environment_variables
-      # Colorize the terminal in the container if possible
-      TERM: "${TERM:-}"
-      # Use the host's X11 display
-      DISPLAY: "${DISPLAY:-}"
-      XAUTHORITY: "${XAUTHORITY:-}"
-      XDG_SESSION_TYPE: "${XDG_SESSION_TYPE:-}"
-      NVIDIA_DRIVER_CAPABILITIES: "all"
+        <<: *common_build_args
+        CUDA_BASE_IMAGE: nvidia/cudagl:${CUDA_VERSION:-11.0}-runtime-${LINUX_VERSION:-ubuntu18.04}
     volumes:
       - &workdir "${PWD}:${PWD}:rw"
       - &etc_fonts "/etc/fonts:/etc/fonts:ro"
@@ -42,12 +47,47 @@ services:
 
   devel:
     <<: *common_service_settings
-    image: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.0}-devel-${LINUX_VERSION:-ubuntu18.04}
+    image: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda${CUDA_VERSION:-11.0}-devel-${LINUX_VERSION:-ubuntu18.04}-amd64
     build:
-      <<: *runtime_build_settings
+      <<: *common_build_settings
       dockerfile: dockerfiles/devel.Dockerfile
-    environment:
-      <<: *runtime_environment_variables
+      args:
+        <<: *common_build_args
+        CUDA_BASE_IMAGE: nvidia/cudagl:${CUDA_VERSION:-11.0}-devel-${LINUX_VERSION:-ubuntu18.04}
+    volumes:
+      - *workdir
+      - *etc_fonts
+      - *x11_socket
+      - *usr_share_fonts
+      - *usr_share_icons
+
+  # Services for Jetson Xavier AGX
+
+  runtime-arm64v8:
+    <<: *common_service_settings
+    image: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda10.2-runtime-ubuntu18.04-arm64v8
+    build:
+      <<: *common_build_settings
+      dockerfile: dockerfiles/runtime.Dockerfile
+      args:
+        <<: *common_build_args
+        CUDA_BASE_IMAGE: nvcr.io/nvidia/l4t-base:r32.4.4
+    volumes:
+      - *workdir
+      - *etc_fonts
+      - *x11_socket
+      - *usr_share_fonts
+      - *usr_share_icons
+
+  devel-arm64v8:
+    <<: *common_service_settings
+    image: rapidsai/js:${RAPIDS_VERSION:-latest}-cuda10.2-devel-ubuntu18.04-arm64v8
+    build:
+      <<: *common_build_settings
+      dockerfile: dockerfiles/devel.Dockerfile
+      args:
+        <<: *common_build_args
+        CUDA_BASE_IMAGE: nvcr.io/nvidia/l4t-base:r32.4.4
     volumes:
       - *workdir
       - *etc_fonts

--- a/dockerfiles/devel.Dockerfile
+++ b/dockerfiles/devel.Dockerfile
@@ -1,23 +1,28 @@
-ARG CUDA_VERSION=11.0
+ARG CUDA_BASE_IMAGE
 ARG NODE_VERSION=14.10.1
-ARG LINUX_VERSION=ubuntu18.04
-ARG CUDA_SHORT_VERSION=${CUDA_VERSION}
 
 FROM node:$NODE_VERSION-stretch-slim as node
 
-FROM nvidia/cudagl:${CUDA_VERSION}-devel-${LINUX_VERSION}
+FROM ${CUDA_BASE_IMAGE}
 
-ARG CUDA_SHORT_VERSION
-ARG PARALLEL_LEVEL=4
-ENV CMAKE_VERSION=3.18.5
-ENV CCACHE_VERSION=4.1
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dev dependencies and tools
-RUN apt update -y && apt upgrade -y \
+RUN GCC_VERSION=$(bash -c '\
+CUDA_VERSION=$(nvcc --version | head -n4 | tail -n1 | cut -d" " -f5 | cut -d"," -f1); \
+CUDA_VERSION_MAJOR=$(echo $CUDA_VERSION | tr -d '.' | cut -c 1-2); \
+CUDA_VERSION_MINOR=$(echo $CUDA_VERSION | tr -d '.' | cut -c 3); \
+  if [[ "$CUDA_VERSION_MAJOR" == 9 ]]; then echo "7"; \
+elif [[ "$CUDA_VERSION_MAJOR" == 10 ]]; then echo "8"; \
+elif [[ "$CUDA_VERSION_MAJOR" == 11 ]]; then echo "9"; \
+else echo "10"; \
+fi') \
+ && apt update -y \
  && apt install -y software-properties-common \
  && add-apt-repository -y ppa:git-core/ppa \
+ && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
  && apt install -y \
+    gcc-${GCC_VERSION} g++-${GCC_VERSION} \
     git nano sudo wget ninja-build bash-completion \
     # ccache dependencies
     unzip automake autoconf libb2-dev libzstd-dev \
@@ -30,9 +35,26 @@ RUN apt update -y && apt upgrade -y \
     # GLEW dependencies
     build-essential libxmu-dev libxi-dev libgl-dev libgl1-mesa-dev libglu1-mesa-dev \
     # cuDF dependencies
-    libboost-filesystem1.71-dev \
+    libboost-filesystem-dev \
  && apt autoremove -y \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+ # Remove any existing gcc and g++ alternatives
+ && update-alternatives --remove-all cc  >/dev/null 2>&1 || true \
+ && update-alternatives --remove-all c++ >/dev/null 2>&1 || true \
+ && update-alternatives --remove-all gcc >/dev/null 2>&1 || true \
+ && update-alternatives --remove-all g++ >/dev/null 2>&1 || true \
+ && update-alternatives --remove-all gcov >/dev/null 2>&1 || true \
+ && update-alternatives \
+    --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 100 \
+    --slave /usr/bin/cc cc /usr/bin/gcc-${GCC_VERSION} \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} \
+    --slave /usr/bin/c++ c++ /usr/bin/g++-${GCC_VERSION} \
+    --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_VERSION} \
+ # Set gcc-${GCC_VERSION} as the default gcc
+ && update-alternatives --set gcc /usr/bin/gcc-${GCC_VERSION}
+
+ARG PARALLEL_LEVEL=4
+ARG CMAKE_VERSION=3.18.5
 
 # Install CMake
 RUN cd /tmp \
@@ -43,6 +65,8 @@ RUN cd /tmp \
     --parallel=$PARALLEL_LEVEL \
  && make install -j$PARALLEL_LEVEL \
  && cd /tmp && rm -rf /tmp/cmake-$CMAKE_VERSION*
+
+ARG CCACHE_VERSION=4.1
 
  # Install ccache
 RUN cd /tmp \
@@ -58,8 +82,11 @@ RUN cd /tmp \
  && make install -j$PARALLEL_LEVEL \
  && cd /tmp && rm -rf /tmp/ccache-$CCACHE_VERSION*
 
+ARG NODE_VERSION
 ENV NODE_VERSION=$NODE_VERSION
-ENV YARN_VERSION=1.22.5
+
+ARG YARN_VERSION=1.22.5
+ENV YARN_VERSION=$YARN_VERSION
 
 # Install node
 COPY --from=node /usr/local/bin/node /usr/local/bin/node
@@ -93,7 +120,7 @@ RUN groupadd --gid $GID node \
  && npm completion > /etc/bash_completion.d/npm
 
 # avoid "OSError: library nvvm not found" error
-ENV CUDA_HOME="/usr/local/cuda-$CUDA_SHORT_VERSION"
+ENV CUDA_HOME="/usr/local/cuda"
 
 SHELL ["/bin/bash", "-l"]
 


### PR DESCRIPTION
* Add docker-compose services for L4T (Jetson etc.)
* Update dockerfiles to build on amd64 and arm64v8

`docker-compose build devel` and `docker-compose build runtime` will be necessary again after these changes