### PR TITLE
[core]: Remove variadic CPPToNapi operator() overload

### DIFF
--- a/modules/core/cmake/Modules/ConfigureCUDF.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUDF.cmake
@@ -33,7 +33,7 @@ function(find_and_configure_cudf VERSION)
         GIT_REPOSITORY  https://github.com/trxcllnt/cudf.git
         # Can also use a local path to your repo clone for testing
         # GIT_REPOSITORY  /home/ptaylor/dev/rapids/cudf
-        GIT_TAG         combined-fixes
+        GIT_TAG         fix/cmake-exports
         GIT_SHALLOW     TRUE
         SOURCE_SUBDIR   cpp
         OPTIONS         "BUILD_TESTS OFF"

--- a/modules/cuda/src/memory/memory.cpp
+++ b/modules/cuda/src/memory/memory.cpp
@@ -98,7 +98,7 @@ Napi::Value cuPointerGetAttributeNapi(CallbackArgs const& args) {
       char* data{nullptr};
       NODE_CU_TRY(cuPointerGetAttribute(&data, attribute, dptr), env);
       NODE_CU_TRY(cuMemGetAddressRange(&base, &size, dptr), env);
-      return CPPToNapi(args)(data, size - (dptr - base));
+      return CPPToNapi(args)({data, size - (dptr - base)});
     }
     // todo?
     case CU_POINTER_ATTRIBUTE_P2P_TOKENS: break;

--- a/modules/cuda/src/node_cuda/utilities/cpp_to_napi.hpp
+++ b/modules/cuda/src/node_cuda/utilities/cpp_to_napi.hpp
@@ -32,7 +32,7 @@ namespace nv {
 
 template <>
 inline Napi::Value CPPToNapi::operator()(cudaUUID_t const& data) const {
-  return this->operator()(data.bytes, sizeof(cudaUUID_t));
+  return this->operator()({data.bytes, sizeof(cudaUUID_t)});
 }
 
 template <>
@@ -89,7 +89,7 @@ inline Napi::Value CPPToNapi::operator()(cudaDeviceProp const& props) const {
       if (std::is_same<P, char const>()) {
         obj.Set(name, cast_t(std::string{reinterpret_cast<char const*>(&val)}));
       } else {
-        obj.Set(name, cast_t(reinterpret_cast<P*>(val), sizeof(val)));
+        obj.Set(name, cast_t(std::make_tuple(reinterpret_cast<P const*>(val), sizeof(val))));
       }
     } else {
       obj.Set(name, cast_t(val));

--- a/modules/glfw/src/monitor.cpp
+++ b/modules/glfw/src/monitor.cpp
@@ -143,12 +143,12 @@ Napi::Value glfwGetGammaRamp(Napi::CallbackInfo const& info) {
   auto env = info.Env();
   CallbackArgs args{info};
   auto ramp    = GLFWAPI::glfwGetGammaRamp(args[0]);
-  auto size    = ramp->size;
+  size_t size  = ramp->size;
   auto js_ramp = Napi::Object::New(env);
   js_ramp.Set("size", CPPToNapi(info)(ramp->size));
-  js_ramp.Set("red", CPPToNapi(info)(ramp->red, size));
-  js_ramp.Set("green", CPPToNapi(info)(ramp->green, size));
-  js_ramp.Set("blue", CPPToNapi(info)(ramp->blue, size));
+  js_ramp.Set("red", CPPToNapi(info)(std::make_tuple(ramp->red, size)));
+  js_ramp.Set("green", CPPToNapi(info)(std::make_tuple(ramp->green, size)));
+  js_ramp.Set("blue", CPPToNapi(info)(std::make_tuple(ramp->blue, size)));
   return js_ramp;
 }
 


### PR DESCRIPTION
Removes variadic the `CPPToNapi::operator()` overload that causes undefined symbol errors at runtime instead of missing overload errors at compile-time.

The the compiler would allow calling the `CPPToNapi{}` functor with any number/type of arguments without generating a compile error. Instead, we'd see a cryptic runtime error about a missing symbol. This was always bad, but was the only way to allow overloads with more than one argument.

This PR switches it back to just a single argument, and changes the only two-argument overload to accept a single `std::tuple` instead of two parameters.