### PR TITLE
Add List DataType and Series

### DIFF
--- a/modules/cudf/src/node_cudf/types.hpp
+++ b/modules/cudf/src/node_cudf/types.hpp
@@ -75,8 +75,10 @@ class DataType : public Napi::ObjectWrap<DataType> {
   static Napi::FunctionReference constructor;
 
   Napi::Value id(Napi::CallbackInfo const& info);
+  Napi::Value children(Napi::CallbackInfo const& info);
 
   cudf::type_id id_{cudf::type_id::EMPTY};
+  Napi::Reference<Napi::Array> children_;
 };
 
 }  // namespace nv

--- a/modules/cudf/src/series/list.ts
+++ b/modules/cudf/src/series/list.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Series} from '../series';
+import {DataType, Int32, List, SeriesType} from '../types';
+
+/**
+ * A Series of lists of values.
+ */
+export class ListSeries<T extends DataType> extends Series<List<T>> {
+  /**
+   * Series of integer offsets for each list
+   */
+  get offsets() { return Series.new(this._col.getChild<Int32>(0)); }
+
+  /**
+   * Series containing the elements of each list
+   */
+  get elements(): SeriesType<T> { return Series.new(this._col.getChild<T>(1)); }
+}

--- a/modules/cudf/src/utilities/dtypes.cpp
+++ b/modules/cudf/src/utilities/dtypes.cpp
@@ -14,6 +14,7 @@
 
 #include <node_cudf/types.hpp>
 #include <node_cudf/utilities/dtypes.hpp>
+#include <node_cudf/utilities/error.hpp>
 #include <node_cudf/utilities/napi_to_cpp.hpp>
 
 #include <cudf/utilities/traits.hpp>
@@ -23,43 +24,39 @@ namespace nv {
 
 namespace {
 
-template <typename _RHS>
-struct get_common_type_t {
-  template <
-    typename LHS,
-    typename RHS                                          = _RHS,
-    typename std::enable_if_t<(std::is_convertible<LHS, RHS>::value && cudf::is_numeric<LHS>() &&
-                               cudf::is_numeric<RHS>())>* = nullptr>
-  cudf::type_id operator()(cudf::data_type const& lhs, cudf::data_type const& rhs) {
+template <typename LHS, typename RHS, typename = void>
+struct common_type_exists : std::false_type {};
+
+template <typename LHS, typename RHS>
+struct common_type_exists<LHS, RHS, std::void_t<std::common_type_t<LHS, RHS>>> : std::true_type {};
+
+struct get_common_type_id {
+  template <typename LHS,
+            typename RHS,
+            typename std::enable_if_t<common_type_exists<LHS, RHS>::value>* = nullptr>
+  cudf::type_id operator()() {
     return cudf::type_to_id<std::common_type_t<LHS, RHS>>();
   }
-  template <
-    typename LHS,
-    typename RHS                                           = _RHS,
-    typename std::enable_if_t<!(std::is_convertible<LHS, RHS>::value && cudf::is_numeric<LHS>() &&
-                                cudf::is_numeric<RHS>())>* = nullptr>
-  cudf::type_id operator()(cudf::data_type const& lhs, cudf::data_type const& rhs) {
-    auto lhs_name = cudf::type_dispatcher(lhs, cudf::type_to_name{});
-    auto rhs_name = cudf::type_dispatcher(rhs, cudf::type_to_name{});
-    CUDF_FAIL("Cannot determine a logical common type between " + lhs_name + " and " + rhs_name);
-  }
-};
-
-struct dispatch_get_common_type_t {
-  template <typename RHS>
-  cudf::type_id operator()(cudf::data_type const& lhs, cudf::data_type const& rhs) {
-    return cudf::type_dispatcher(lhs, get_common_type_t<RHS>{}, lhs, rhs);
+  template <typename LHS,
+            typename RHS,
+            typename std::enable_if_t<not common_type_exists<LHS, RHS>::value>* = nullptr>
+  cudf::type_id operator()() {
+    CUDF_FAIL("Cannot determine a logical common type between " +
+              cudf::type_to_name{}.operator()<LHS>() + " and " +
+              cudf::type_to_name{}.operator()<RHS>());
   }
 };
 
 }  // namespace
 
 cudf::type_id get_common_type(cudf::data_type const& lhs, cudf::data_type const& rhs) {
-  return cudf::type_dispatcher(rhs, dispatch_get_common_type_t{}, lhs, rhs);
+  return cudf::double_type_dispatcher(lhs, rhs, get_common_type_id{});
 }
 
 Napi::Value find_common_type(CallbackArgs const& args) {
-  return DataType::New(get_common_type(args[0], args[1]))->Value();
+  try {
+    return DataType::New(get_common_type(args[0], args[1]))->Value();
+  } catch (cudf::logic_error const& err) { NODE_CUDF_THROW(err.what()); }
 }
 
 }  // namespace nv

--- a/modules/cudf/test/series/list-tests.ts
+++ b/modules/cudf/test/series/list-tests.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import '../jest-extensions';
+
+import {setDefaultAllocator} from '@nvidia/cuda';
+import {Int32, List, Series, SeriesType} from '@nvidia/cudf';
+import {CudaMemoryResource, DeviceBuffer} from '@nvidia/rmm';
+import * as arrow from 'apache-arrow';
+import {VectorType} from 'apache-arrow/interfaces';
+
+const mr = new CudaMemoryResource();
+
+setDefaultAllocator((byteLength) => new DeviceBuffer(byteLength, mr));
+
+describe('ListSeries', () => {
+  const validateOffsets = (vec: VectorType<arrow.List>, col: SeriesType<List>) => {
+    const expectedOffsets = vec.valueOffsets.subarray(0, vec.length + 1);
+    const actualOffsets   = col.offsets.data.toArray();
+    expect(expectedOffsets).toEqualTypedArray(actualOffsets);
+  };
+
+  const validateElements = (vec: VectorType<arrow.Int32>, col: SeriesType<Int32>) => {
+    const expectedElements = vec.values.subarray(0, vec.length);
+    const actualElements   = col.data.toArray();
+    expect(expectedElements).toEqualTypedArray(actualElements);
+  };
+
+  test('Can create from Arrow', () => {
+    const vec  = listsOfInt32s([[0, 1, 2], [3, 4, 5]]);
+    const ints = vec.getChildAt<arrow.Int32>(0)! as VectorType<arrow.Int32>;
+    const col  = Series.new(vec);
+
+    validateOffsets(vec, col);
+    validateElements(ints, col.elements);
+  });
+
+  test('Can create a List of Lists from Arrow', () => {
+    const vec  = listsOfListsOfInt32s([[[0, 1, 2]], [[3, 4, 5], [7, 8, 9]]]);
+    const list = vec.getChildAt<ListOfInt32>(0)! as VectorType<ListOfInt32>;
+    const ints = list.getChildAt<arrow.Int32>(0)! as VectorType<arrow.Int32>;
+    const col  = Series.new(vec);
+
+    validateOffsets(vec, col);
+    validateOffsets(list, col.elements);
+    validateElements(ints, col.elements.elements);
+  });
+});
+
+type ListOfInt32 = arrow.List<arrow.Int32>;
+type ListOfLists = arrow.List<ListOfInt32>;
+
+function listsOfInt32s(values: number[][]) {
+  return arrow.Vector.from({
+    values,
+    type: new arrow.List(arrow.Field.new({name: 'ints', type: new arrow.Int32})),
+  }) as VectorType<ListOfInt32>;
+}
+
+function listsOfListsOfInt32s(values: number[][][]) {
+  return arrow.Vector.from({
+    values,
+    type: new arrow.List(arrow.Field.new({
+      name: 'lists',
+      type: new arrow.List(arrow.Field.new({name: 'ints', type: new arrow.Int32}))
+    })),
+  }) as VectorType<ListOfLists>;
+}


### PR DESCRIPTION
Adds an initial implementation of the cudf List DataType and Series.

Lists aren't fully implemented in libcudf yet, but this is rough parity with the cudf Python version.