### PR TITLE
Add container user to video group on Jetson, set default user at build time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ x-common-service-settings: &common_service_settings
     context: .
     args: &common_build_args
       UID: ${UID:-1000}
-      GID: ${GID:-1000}
       ADDITIONAL_GROUPS: ""
       NODE_VERSION: "${NODE_VERSION:-14.10.1}"
       YARN_VERSION: "${YARN_VERSION:-1.22.5}"

--- a/dockerfiles/devel.Dockerfile
+++ b/dockerfiles/devel.Dockerfile
@@ -106,12 +106,9 @@ COPY --from=node /opt/yarn-v$YARN_VERSION/lib/v8-compile-cache.js /usr/local/lib
 COPY --from=node /usr/local/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 ARG UID=1000
-ARG GID=1000
 ARG ADDITIONAL_GROUPS=
 
-RUN groupadd --gid $GID node \
- && useradd --uid $UID --gid node ${ADDITIONAL_GROUPS} --shell /bin/bash --create-home node \
- && echo root:root | chpasswd \
+RUN useradd --uid $UID --user-group ${ADDITIONAL_GROUPS} --shell /bin/bash --create-home node \
  && echo node:node | chpasswd \
  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
  && ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \

--- a/dockerfiles/runtime.Dockerfile
+++ b/dockerfiles/runtime.Dockerfile
@@ -37,11 +37,9 @@ COPY --from=node /opt/yarn-v$YARN_VERSION/lib/v8-compile-cache.js /usr/local/lib
 COPY --from=node /usr/local/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 ARG UID=1000
-ARG GID=1000
 ARG ADDITIONAL_GROUPS=
 
-RUN groupadd --gid $GID node \
- && useradd --uid $UID --gid node ${ADDITIONAL_GROUPS} --shell /bin/bash --create-home node \
+RUN useradd --uid $UID --user-group ${ADDITIONAL_GROUPS} --shell /bin/bash --create-home node \
  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
  && ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
  && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \


### PR DESCRIPTION
* Add container user to video group on Jetson
* Set default container user at build time

These changes are necessary for non-root users to execute GPU programs inside a container on Jetson.