### PR TITLE
Fix runtime error caused by creating a DeviceBuffer from a pointer/span of a JS ArrayBuffer

### DIFF
--- a/modules/core/include/nv_node/utilities/cpp_to_napi.hpp
+++ b/modules/core/include/nv_node/utilities/cpp_to_napi.hpp
@@ -172,13 +172,6 @@ struct CPPToNapi {
   //
   // Pointers
   //
-  // inline Napi::External<void> operator()(void* data) const {
-  //   return Napi::External<void>::New(env, static_cast<char*>(data));
-  // }
-
-  // Napi::String inline operator()(const char* val) const {
-  //   return Napi::String::New(env, (val == NULL) ? "" : val);
-  // }
 
   template <typename T>
   inline Napi::Value operator()(T* data) const {
@@ -200,13 +193,10 @@ struct CPPToNapi {
 
   template <typename T>
   inline Napi::Value operator()(Span<T> const& span) const {
-    return buffer_to_typed_array<T>(Napi::ArrayBuffer::New(env, span.data(), span.size()));
-  }
-
-  template <typename T, typename Finalizer>
-  inline Napi::Value operator()(Span<T> const& span, Finalizer finalizer) const {
-    return buffer_to_typed_array<T>(
-      Napi::ArrayBuffer::New(env, span.data(), span.size(), finalizer));
+    auto obj          = Napi::Object::New(env);
+    obj["ptr"]        = span.addr();
+    obj["byteLength"] = span.size();
+    return obj;
   }
 
 #ifdef GLEW_VERSION

--- a/modules/rmm/src/device_buffer.cpp
+++ b/modules/rmm/src/device_buffer.cpp
@@ -62,6 +62,15 @@ ObjectUnwrap<DeviceBuffer> DeviceBuffer::New(Napi::ArrayBuffer const& data,
   return constructor.New(data, mr.object(), stream);
 }
 
+ObjectUnwrap<DeviceBuffer> DeviceBuffer::New(Span<char> const& data,
+                                             ObjectUnwrap<MemoryResource> const& mr,
+                                             rmm::cuda_stream_view stream) {
+  NODE_CUDA_EXPECT(MemoryResource::is_instance(mr.object()),
+                   "DeviceBuffer constructor requires a valid MemoryResource",
+                   constructor.Env());
+  return constructor.New(data, mr.object(), stream);
+}
+
 ObjectUnwrap<DeviceBuffer> DeviceBuffer::New(void* const data,
                                              size_t const size,
                                              ObjectUnwrap<MemoryResource> const& mr,

--- a/modules/rmm/src/node_rmm/device_buffer.hpp
+++ b/modules/rmm/src/node_rmm/device_buffer.hpp
@@ -52,20 +52,6 @@ struct DeviceBuffer : public Napi::ObjectWrap<DeviceBuffer> {
   }
 
   /**
-   * @brief Construct a new DeviceBuffer instance from C++.
-   *
-   * @param data Pointer to the host or device memory to copy from.
-   * @param stream CUDA stream on which memory may be allocated if the memory
-   * resource supports streams.
-   */
-  inline static ObjectUnwrap<DeviceBuffer> New(
-    Span<char> const& data,
-    ObjectUnwrap<MemoryResource> const& mr = MemoryResource::Cuda(),
-    rmm::cuda_stream_view stream           = rmm::cuda_stream_default) {
-    return DeviceBuffer::New(data.data(), data.size(), mr, stream);
-  }
-
-  /**
    * @brief Construct a new DeviceBuffer instance from an Array.
    *
    * @param data Array to copy from.
@@ -90,6 +76,18 @@ struct DeviceBuffer : public Napi::ObjectWrap<DeviceBuffer> {
    */
   static ObjectUnwrap<DeviceBuffer> New(
     Napi::ArrayBuffer const& data,
+    ObjectUnwrap<MemoryResource> const& mr = MemoryResource::Cuda(),
+    rmm::cuda_stream_view stream           = rmm::cuda_stream_default);
+
+  /**
+   * @brief Construct a new DeviceBuffer instance from C++.
+   *
+   * @param data Pointer to the host or device memory to copy from.
+   * @param stream CUDA stream on which memory may be allocated if the memory
+   * resource supports streams.
+   */
+  static ObjectUnwrap<DeviceBuffer> New(
+    Span<char> const& data,
     ObjectUnwrap<MemoryResource> const& mr = MemoryResource::Cuda(),
     rmm::cuda_stream_view stream           = rmm::cuda_stream_default);
 


### PR DESCRIPTION
Fixes a potential runtime error when constructing a `DeviceBuffer` from C++ triggered by accidentally wrapping a pointer to an owning JS `ArrayBuffer` in a non-owning `ArrayBuffer`.