### PR TITLE
[FIX] Update libstdc++-6 for Ubuntu18.04 runtime containers

### DIFF
--- a/.github/workflows/main.pr.yml
+++ b/.github/workflows/main.pr.yml
@@ -76,16 +76,15 @@ jobs:
               rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }} \
               ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }}
           fi
-          docker run --rm \
-            -v "$(pwd):/opt/rapids/node:rw" \
-            -e "DISPLAY=:0.0" \
-            -e "CUDAARCHS=ALL" \
-            -e "PARALLEL_LEVEL=1" \
-            -e "SCCACHE_CACHE_SIZE=100G" \
-            -e "SCCACHE_IDLE_TIMEOUT=32768" \
-            -e "SCCACHE_REGION=us-west-2" \
-            -e "SCCACHE_BUCKET=node-rapids-sccache" \
-            -e "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" \
-            -e "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
+          echo "DISPLAY=:0.0" >> .env
+          echo "CUDAARCHS=ALL" >> .env
+          echo "PARALLEL_LEVEL=1" >> .env
+          echo "SCCACHE_CACHE_SIZE=100G" >> .env
+          echo "SCCACHE_IDLE_TIMEOUT=32768" >> .env
+          echo "SCCACHE_REGION=us-west-2" >> .env
+          echo "SCCACHE_BUCKET=node-rapids-sccache" >> .env
+          echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> .env
+          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> .env
+          docker run --rm --env-file .env -v "$(pwd):/opt/rapids/node:rw" \
             ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }} \
             bash -c 'set -x; echo $PATH; echo $CUDA_HOME; which -a nvcc; nvcc --version; yarn; yarn rebuild'

--- a/.github/workflows/main.pr.yml
+++ b/.github/workflows/main.pr.yml
@@ -86,6 +86,7 @@ jobs:
           echo "SCCACHE_BUCKET=node-rapids-sccache" >> .env
           echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> .env
           echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> .env
-          docker run --rm --env-file .env -u "$(id -u):$(id -g)" -v "$(pwd):/opt/rapids/node:rw" \
+          mkdir -p /tmp/.cache
+          docker run --rm --env-file .env -u "$(id -u):$(id -g)" -v "$(pwd):/opt/rapids/node:rw" -v "/tmp/.cache:/.cache:rw" \
             ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }} \
-            bash -c 'set -x; echo $PATH; echo $CUDA_HOME; which -a nvcc; nvcc --version; yarn; yarn rebuild'
+            bash -c 'set -ex; echo $PATH && echo $CUDA_HOME && which -a nvcc && nvcc --version && yarn && yarn rebuild'

--- a/.github/workflows/main.pr.yml
+++ b/.github/workflows/main.pr.yml
@@ -55,6 +55,13 @@ jobs:
             ${{ runner.os }}-${{ env.RAPIDS }}-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-${{ env.ARCH }}-node_modules-
           path: |
             node_modules
+      - name: Check if devel dockerfiles changed
+        id: devel_dockerfiles_changed
+        uses: tj-actions/changed-files@v9.1
+        with:
+          files: |
+            dockerfiles/devel/01-base.Dockerfile
+            dockerfiles/devel/02-main.Dockerfile
       - name: Build devel images and packages
         run: |
           echo "UID=$(id -u)" >> .env
@@ -63,7 +70,12 @@ jobs:
           echo "CUDA_VERSION=${{ matrix.CUDA }}" >> .env
           echo "RAPIDS_VERSION=${{ env.RAPIDS }}" >> .env
           echo "LINUX_VERSION=${{ matrix.LINUX }}" >> .env
-          yarn docker:build:devel
+          if [[ "${{ steps.devel_dockerfiles_changed.outputs.any_changed }}" == "true" ]]; then
+            yarn docker:build:devel
+            docker image tag \
+              rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }} \
+              ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }}
+          fi
           docker run --rm \
             -v "$(pwd):/opt/rapids/node:rw" \
             -e "DISPLAY=:0.0" \
@@ -75,5 +87,5 @@ jobs:
             -e "SCCACHE_BUCKET=node-rapids-sccache" \
             -e "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" \
             -e "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
-            rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }} \
-            yarn && yarn rebuild
+            ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }} \
+            echo \$PATH && echo \$CUDA_HOME && which -a nvcc && nvcc --version && yarn && yarn rebuild

--- a/.github/workflows/main.pr.yml
+++ b/.github/workflows/main.pr.yml
@@ -88,4 +88,4 @@ jobs:
             -e "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" \
             -e "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
             ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }} \
-            echo \$PATH && echo \$CUDA_HOME && which -a nvcc && nvcc --version && yarn && yarn rebuild
+            bash -c 'set -x; echo $PATH; echo $CUDA_HOME; which -a nvcc; nvcc --version; yarn; yarn rebuild'

--- a/.github/workflows/main.pr.yml
+++ b/.github/workflows/main.pr.yml
@@ -86,7 +86,7 @@ jobs:
           echo "SCCACHE_BUCKET=node-rapids-sccache" >> .env
           echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> .env
           echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> .env
-          mkdir -p /tmp/.cache
-          docker run --rm --env-file .env -u "$(id -u):$(id -g)" -v "$(pwd):/opt/rapids/node:rw" -v "/tmp/.cache:/.cache:rw" \
+          mkdir -p /tmp/.yarn /tmp/.cache
+          docker run --rm --env-file .env -u "$(id -u):$(id -g)" -v "$(pwd):/opt/rapids/node:rw" -v "/tmp/.yarn:/.yarn:rw" -v "/tmp/.cache:/.cache:rw" \
             ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }} \
             bash -c 'set -ex; echo $PATH && echo $CUDA_HOME && which -a nvcc && nvcc --version && yarn && yarn rebuild'

--- a/.github/workflows/main.pr.yml
+++ b/.github/workflows/main.pr.yml
@@ -76,4 +76,4 @@ jobs:
             -e "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" \
             -e "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
             rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }} \
-            yarn nuke:from:orbit
+            yarn && yarn rebuild

--- a/.github/workflows/main.pr.yml
+++ b/.github/workflows/main.pr.yml
@@ -64,13 +64,14 @@ jobs:
             dockerfiles/devel/02-main.Dockerfile
       - name: Build devel images and packages
         run: |
-          echo "UID=$(id -u)" >> .env
-          echo "ARCH=${{ env.ARCH }}" >> .env
-          echo "NODE_VERSION=${{ env.NODE }}" >> .env
-          echo "CUDA_VERSION=${{ matrix.CUDA }}" >> .env
-          echo "RAPIDS_VERSION=${{ env.RAPIDS }}" >> .env
-          echo "LINUX_VERSION=${{ matrix.LINUX }}" >> .env
+          echo "$(id -u):$(id -g)"
           if [[ "${{ steps.devel_dockerfiles_changed.outputs.any_changed }}" == "true" ]]; then
+            echo "UID=$(id -u)" >> .env
+            echo "ARCH=${{ env.ARCH }}" >> .env
+            echo "NODE_VERSION=${{ env.NODE }}" >> .env
+            echo "CUDA_VERSION=${{ matrix.CUDA }}" >> .env
+            echo "RAPIDS_VERSION=${{ env.RAPIDS }}" >> .env
+            echo "LINUX_VERSION=${{ matrix.LINUX }}" >> .env
             yarn docker:build:devel
             docker image tag \
               rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }} \
@@ -85,6 +86,6 @@ jobs:
           echo "SCCACHE_BUCKET=node-rapids-sccache" >> .env
           echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> .env
           echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> .env
-          docker run --rm --env-file .env -v "$(pwd):/opt/rapids/node:rw" \
+          docker run --rm --env-file .env -u "$(id -u):$(id -g)" -v "$(pwd):/opt/rapids/node:rw" \
             ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }} \
             bash -c 'set -x; echo $PATH; echo $CUDA_HOME; which -a nvcc; nvcc --version; yarn; yarn rebuild'

--- a/dockerfiles/runtime/01-base.Dockerfile
+++ b/dockerfiles/runtime/01-base.Dockerfile
@@ -16,6 +16,23 @@ ${CUDA_HOME}/lib64:\
 /usr/local/lib:\
 /usr/lib"
 
+# Install gcc-9 toolchain
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt update \
+ && apt install --no-install-recommends -y \
+    software-properties-common \
+ && add-apt-repository --no-update -y ppa:ubuntu-toolchain-r/test \
+ && apt update \
+ && apt install --no-install-recommends -y \
+    libstdc++6 \
+ # Clean up
+ && add-apt-repository --remove -y ppa:ubuntu-toolchain-r/test \
+ && apt autoremove -y && apt clean \
+ && rm -rf \
+    /tmp/* \
+    /var/tmp/* \
+    /var/lib/apt/lists/*
+
 # Install node
 COPY --from=devel /usr/local/bin/node                 /usr/local/bin/node
 COPY --from=devel /usr/local/include/node             /usr/local/include/node


### PR DESCRIPTION
We're compiling with gcc-9 but Ubuntu 18.04's default toolchain is gcc-7, leading to errors importing the compiled libs in the `ubuntu18.04` runtime containers. This PR updates `libstdc++6` in the runtime containers via the ubuntu-toolchain PPA.