### PR TITLE
[FIX] Empty dataframe initialization

### DIFF
--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -142,7 +142,7 @@ export class DataFrame<T extends TypeMap = any> {
    *
    * ```
    */
-  constructor(data: ColumnAccessor<T>|SeriesMap<T>) {
+  constructor(data: ColumnAccessor<T>|SeriesMap<T> = {} as SeriesMap<T>) {
     this._accessor =
       (data instanceof ColumnAccessor) ? data : new ColumnAccessor(_seriesToColumns(data));
   }
@@ -162,7 +162,7 @@ export class DataFrame<T extends TypeMap = any> {
    * df.numRows // 2
    * ```
    */
-  get numRows() { return this._accessor.columns[0].length; }
+  get numRows() { return this._accessor.columns.length > 0 ? this._accessor.columns[0].length : 0; }
 
   /**
    * The number of columns in this DataFrame

--- a/modules/cudf/test/cudf-data-frame-tests.ts
+++ b/modules/cudf/test/cudf-data-frame-tests.ts
@@ -48,6 +48,18 @@ test('DataFrame initialization', () => {
   expect(table_0.get('col_1').type.typeId).toBe(col_1.type.typeId);
 });
 
+test('Empty DataFrame initialization', () => {
+  const table_0 = new DataFrame({});
+  expect(table_0.numColumns).toBe(0);
+  expect(table_0.numColumns).toBe(0);
+  expect(table_0.names).toStrictEqual([]);
+
+  const table_1 = new DataFrame();
+  expect(table_1.numColumns).toBe(0);
+  expect(table_1.numColumns).toBe(0);
+  expect(table_1.names).toStrictEqual([]);
+});
+
 test('DataFrame asTable', () => {
   const length = 100;
   const col_0  = Series.new({type: new Int32(), data: new Int32Buffer(length)});

--- a/modules/cudf/test/cudf-data-frame-tests.ts
+++ b/modules/cudf/test/cudf-data-frame-tests.ts
@@ -51,12 +51,12 @@ test('DataFrame initialization', () => {
 test('Empty DataFrame initialization', () => {
   const table_0 = new DataFrame({});
   expect(table_0.numColumns).toBe(0);
-  expect(table_0.numColumns).toBe(0);
+  expect(table_0.numRows).toBe(0);
   expect(table_0.names).toStrictEqual([]);
 
   const table_1 = new DataFrame();
   expect(table_1.numColumns).toBe(0);
-  expect(table_1.numColumns).toBe(0);
+  expect(table_1.numRows).toBe(0);
   expect(table_1.names).toStrictEqual([]);
 });
 


### PR DESCRIPTION
I needed this fix for my current branch which uses an empty `dataframe`. I did a search for any other `columns[0]` accessing without checking length but couldn't find any others.

Closes #259 