### PR TITLE
Add pretty-printing df.toString

### DIFF
--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -22,6 +22,7 @@ import {Column} from './column';
 import {ColumnAccessor} from './column_accessor';
 import {concat as concatDataFrames} from './dataframe/concat';
 import {Join, JoinResult} from './dataframe/join';
+import {DataFrameFormatter, DisplayOptions} from './dataframe/print';
 import {GroupByMultiple, GroupByMultipleProps, GroupBySingle, GroupBySingleProps} from './groupby';
 import {Scalar} from './scalar';
 import {AbstractSeries, Series} from './series';
@@ -222,6 +223,16 @@ export class DataFrame<T extends TypeMap = any> {
 
   /** @ignore */
   asTable() { return new Table({columns: this._accessor.columns}); }
+
+  /**
+   *
+   * @param options
+   * @returns void
+   */
+  toString(options?: DisplayOptions): string {
+    const formatter = new DataFrameFormatter(options ?? {}, this);
+    return formatter.render();
+  }
 
   /**
    * Return a new DataFrame containing only specified columns.

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -225,12 +225,14 @@ export class DataFrame<T extends TypeMap = any> {
   asTable() { return new Table({columns: this._accessor.columns}); }
 
   /**
+   * Return a string with a tabular representation of the DataFrame, pretty-printed according to the
+   * options given.
    *
    * @param options
    * @returns void
    */
-  toString(options?: DisplayOptions): string {
-    const formatter = new DataFrameFormatter(options ?? {}, this);
+  toString(options: DisplayOptions = {}): string {
+    const formatter = new DataFrameFormatter(options, this);
     return formatter.render();
   }
 

--- a/modules/cudf/src/dataframe/print.ts
+++ b/modules/cudf/src/dataframe/print.ts
@@ -40,7 +40,7 @@ export type DisplayOptions = {
   maxRows?: number,
 
   /**
-   * Width of the display in characters. (default: 80)
+   * Width of the display in characters. A value of zero means unlimited. (default: 0)
    */
   width?: number,
 
@@ -63,7 +63,7 @@ export class DataFrameFormatter<T extends TypeMap> {
     this.maxColumns  = options.maxColumns ?? 20;
     this.maxColWidth = options.maxColWidth ?? 50;
     this.maxRows     = options.maxRows ?? 60;
-    this.width       = options.width ?? 80;
+    this.width       = options.width ?? 0;
     this.htrunc      = false;
     this.vtrunc      = false;
 
@@ -73,7 +73,7 @@ export class DataFrameFormatter<T extends TypeMap> {
 
     this.measuredWidths = this._measureWidths(tmp);
 
-    while (this._totalWidth(tmp) > this.width) {
+    while (this.width > 0 && this._totalWidth(tmp) > this.width) {
       this.htrunc = true;
       const names = [...tmp.names];
       const N     = Math.ceil((names.length - 1) / 2);

--- a/modules/cudf/src/dataframe/print.ts
+++ b/modules/cudf/src/dataframe/print.ts
@@ -20,13 +20,14 @@ import {TypeMap} from '../types/mappings';
 export type DisplayOptions = {
   /**
    * The maximum number of columns to display before truncation. Truncation may also occur
-   * if the total printed width in characters exceeds `widht
+   * if the total printed width in characters exceeds `width`
+   * (default: 20)
    *
    */
   maxColumns?: number,
 
   /**
-   * The maximum width in characters of a column when printing a DataFram. When the column *
+   * The maximum width in characters of a column when printing a DataFrame. When the column *
    * overflows, a "..." placeholder is embedded in the output. A value of zero means unlimited.
    * (default: 50)
    */

--- a/modules/cudf/src/dataframe/print.ts
+++ b/modules/cudf/src/dataframe/print.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {DataFrame} from '../data_frame';
+import {Series} from '../series';
+import {Int32, Utf8String} from '../types/dtypes';
+import {TypeMap} from '../types/mappings';
+
+export type DisplayOptions = {
+  /**
+   * The maximum number of columns to display before truncation. Truncation may also occur
+   * if the total printed width in characters exceeds `widht
+   *
+   */
+  maxColumns?: number,
+
+  /**
+   * The maximum width in characters of a column when printing a DataFram. When the column *
+   * overflows, a "..." placeholder is embedded in the output. A value of zero means unlimited.
+   * (default: 50)
+   */
+  maxColWidth?: number,
+
+  /**
+   * The maximum number of rows to output when printing a DataFrame.  A value of zero means
+   * unlimited. (default: 60)
+   */
+  maxRows?: number,
+
+  /**
+   * Width of the display in characters. (default: 80)
+   */
+  width?: number,
+
+}
+
+export class DataFrameFormatter<T extends TypeMap> {
+  private obj: DataFrame;
+  private maxColumns: number;
+  private maxColWidth: number;
+  private maxRows: number;
+  private width: number;
+  private htrunc: boolean;
+  private vtrunc: boolean;
+
+  constructor(options: DisplayOptions, obj: DataFrame<T>) {
+    this.maxColumns  = options.maxColumns ?? 20;
+    this.maxColWidth = options.maxColWidth ?? 50;
+    this.maxRows     = options.maxRows ?? 60;
+    this.width       = options.width ?? 80;
+    this.htrunc      = false;
+    this.vtrunc      = false;
+
+    let tmp = this.preprocess(obj);
+    while (this._totalWidth(tmp) > this.width) {
+      this.htrunc = true;
+      const names = [...tmp.names];
+      const N     = Math.ceil((names.length - 1) / 2);
+      tmp         = tmp.drop([names[N]]);
+    }
+    this.obj = tmp;
+  }
+
+  preprocess(obj: DataFrame<T>) {
+    let tmp: DataFrame = obj;
+
+    if (this.maxColumns > 0 && tmp.numColumns > this.maxColumns) {
+      this.htrunc       = true;
+      const half        = this.maxColumns / 2;
+      const first       = Math.ceil(half);
+      const last        = this.maxColumns - first;
+      const last_names  = last == 0 ? [] : tmp.names.slice(-last);
+      const trunc_names = [...tmp.names.slice(0, first), ...last_names];
+      tmp               = tmp.select(trunc_names);
+    }
+
+    if (this.maxRows > 0 && tmp.numRows > this.maxRows - 1) {
+      this.vtrunc = true;
+      const half  = (this.maxRows - 1) / 2;
+      const first = Math.ceil(half);
+      const last  = this.maxRows - first - 1;
+      tmp         = tmp.head(first).concat(tmp.tail(last));
+    }
+    return tmp.castAll(new Utf8String).replaceNulls('null');
+  }
+
+  render(): string {
+    const headers: string[] = [...this.obj.names];
+    const widths: number[]  = this._computeWidths(this.obj, headers);
+    const lines             = [];
+
+    lines.push(this._formatFields(headers, widths, '   '));
+
+    for (let i = 0; i < this.obj.numRows; ++i) {
+      const fields = headers.map((name: string) => this.obj.get(name).getValue(i));
+      lines.push(this._formatFields(fields, widths));
+    }
+
+    if (this.vtrunc) {
+      const N    = 1 + Math.floor((lines.length - 1) / 2);  // 1+ for header row
+      const dots = Array(headers.length).fill('...');
+      lines.splice(N, 1, this._formatFields(dots, widths));
+    }
+    lines.push('');
+
+    return lines.join('\n');
+  }
+
+  _totalWidth(obj: DataFrame) {
+    const widths = this._computeWidths(obj, [...obj.names]);
+    return widths.reduce((x, y) => x + y, 0) + widths.length;
+  }
+
+  _computeWidths(obj: DataFrame, headers: string[]) {
+    const inds   = Series.sequence({type: new Int32, size: obj.numRows, init: 0});
+    const widths = [];
+    for (const name of headers) {
+      const lengths   = obj.get(name).len();
+      const truncated = lengths.scatter(3, inds.gather(lengths.gt(this.maxColWidth)));  // '...'
+      widths.push(Math.max(name.length, truncated.max()));
+    }
+
+    return widths;
+  }
+
+  _formatFields(rawFields: string[], rawWidths: number[], placeholder = '...') {
+    const fields = [...rawFields];
+    const widths = [...rawWidths];
+    if (this.htrunc) {
+      const N = Math.ceil(rawFields.length / 2);
+      fields.splice(N, 0, placeholder);
+      widths.splice(N, 0, 3);
+    }
+
+    const truncated = fields.map((val: string) => val.length > this.maxColWidth ? '...' : val);
+
+    return truncated.map((val: string, i: number) => val.padStart(widths[i], ' ')).join(' ');
+  }
+}

--- a/modules/cudf/test/dataframe/print-tests.ts
+++ b/modules/cudf/test/dataframe/print-tests.ts
@@ -1,0 +1,285 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {DataFrame, Int32, Series} from '@rapidsai/cudf';
+
+const a = Series.new([0, 1, 2, 3, 4, 5, 6]);
+const b = Series.new([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.61234567]);
+const c = Series.new([
+  'foo',
+  null,
+  null,
+  'bar',
+  'baz',
+  null,
+  '123456789012345678901234567890123456789012345678901234567890'
+]);
+const d = a.log();
+
+describe('dataframe.toString', () => {
+  test('single column', () => {
+    expect(new DataFrame({'a': a}).toString())
+      .toEqual(
+        `\
+  a
+0.0
+1.0
+2.0
+3.0
+4.0
+5.0
+6.0
+`);
+
+    expect(new DataFrame({'b': b}).toString())
+      .toEqual(
+        `\
+         b
+       0.0
+       1.1
+       2.2
+       3.3
+       4.4
+       5.5
+6.61234567
+`);
+  });
+
+  test('exceeds maxColWidth', () => {
+    expect(new DataFrame({'c': c}).toString())
+      .toEqual(
+        `\
+   c
+ foo
+null
+null
+ bar
+ baz
+null
+ ...
+`);
+  });
+
+  test('maxColWidth', () => {
+    expect(new DataFrame({'b': b, 'c': c}).toString({maxColWidth: 70}))
+      .toEqual(
+        `\
+         b                                                            c
+       0.0                                                          foo
+       1.1                                                         null
+       2.2                                                         null
+       3.3                                                          bar
+       4.4                                                          baz
+       5.5                                                         null
+6.61234567 123456789012345678901234567890123456789012345678901234567890
+`);
+  });
+
+  test('exceeds width', () => {
+    expect(new DataFrame({'a': a, 'b': b, 'c': c, 'd': d}).toString({maxColWidth: 70}))
+      .toEqual(
+        `\
+  a          b               d
+0.0        0.0 ...        -Inf
+1.0        1.1 ...         0.0
+2.0        2.2 ... 0.693147181
+3.0        3.3 ... 1.098612289
+4.0        4.4 ... 1.386294361
+5.0        5.5 ... 1.609437912
+6.0 6.61234567 ... 1.791759469
+`);
+  });
+
+  test('maxRows', () => {
+    // 3
+    expect(new DataFrame({'a': a, 'b': b, 'c': c, 'd': d}).toString({maxRows: 3}))
+      .toEqual(
+        `\
+  a          b   c           d
+0.0        0.0 foo        -Inf
+...        ... ...         ...
+`);
+
+    // 4
+    expect(new DataFrame({'a': a, 'b': b, 'c': c, 'd': d}).toString({maxRows: 4}))
+      .toEqual(
+        `\
+  a          b    c           d
+0.0        0.0  foo        -Inf
+...        ...  ...         ...
+6.0 6.61234567  ... 1.791759469
+`);
+
+    // 5
+    expect(new DataFrame({'a': a, 'b': b, 'c': c, 'd': d}).toString({maxRows: 5}))
+      .toEqual(
+        `\
+  a          b    c           d
+0.0        0.0  foo        -Inf
+1.0        1.1 null         0.0
+...        ...  ...         ...
+6.0 6.61234567  ... 1.791759469
+`);
+
+    // 6
+    expect(new DataFrame({'a': a, 'b': b, 'c': c, 'd': d}).toString({maxRows: 6}))
+      .toEqual(
+        `\
+  a          b    c           d
+0.0        0.0  foo        -Inf
+1.0        1.1 null         0.0
+...        ...  ...         ...
+5.0        5.5 null 1.609437912
+6.0 6.61234567  ... 1.791759469
+`);
+
+    // 7
+    expect(new DataFrame({'a': a, 'b': b, 'c': c, 'd': d}).toString({maxRows: 7}))
+      .toEqual(
+        `\
+  a          b    c           d
+0.0        0.0  foo        -Inf
+1.0        1.1 null         0.0
+2.0        2.2 null 0.693147181
+...        ...  ...         ...
+5.0        5.5 null 1.609437912
+6.0 6.61234567  ... 1.791759469
+`);
+
+    // 8
+    expect(new DataFrame({'a': a, 'b': b, 'c': c, 'd': d}).toString({maxRows: 8}))
+      .toEqual(
+        `\
+  a          b    c           d
+0.0        0.0  foo        -Inf
+1.0        1.1 null         0.0
+2.0        2.2 null 0.693147181
+3.0        3.3  bar 1.098612289
+4.0        4.4  baz 1.386294361
+5.0        5.5 null 1.609437912
+6.0 6.61234567  ... 1.791759469
+`);
+    // 9 (+1)
+    expect(new DataFrame({'a': a, 'b': b, 'c': c, 'd': d}).toString({maxRows: 9}))
+      .toEqual(
+        `\
+  a          b    c           d
+0.0        0.0  foo        -Inf
+1.0        1.1 null         0.0
+2.0        2.2 null 0.693147181
+3.0        3.3  bar 1.098612289
+4.0        4.4  baz 1.386294361
+5.0        5.5 null 1.609437912
+6.0 6.61234567  ... 1.791759469
+`);
+  });
+
+  test('maxColumns', () => {
+    const df = new DataFrame({'a': a, 'b': b, 'c': c, 'd': d});
+
+    // 1
+    expect(df.toString({maxColumns: 1}))
+      // editor trims significant trailing whitespace in a template string
+      .toEqual('  a    \n0.0 ...\n1.0 ...\n2.0 ...\n3.0 ...\n4.0 ...\n5.0 ...\n6.0 ...\n');
+
+    // 2
+    expect(df.toString({maxColumns: 2}))
+      .toEqual(
+        `\
+  a               d
+0.0 ...        -Inf
+1.0 ...         0.0
+2.0 ... 0.693147181
+3.0 ... 1.098612289
+4.0 ... 1.386294361
+5.0 ... 1.609437912
+6.0 ... 1.791759469
+`);
+
+    // 3
+    expect(df.toString({maxColumns: 3}))
+      .toEqual(
+        `\
+  a          b               d
+0.0        0.0 ...        -Inf
+1.0        1.1 ...         0.0
+2.0        2.2 ... 0.693147181
+3.0        3.3 ... 1.098612289
+4.0        4.4 ... 1.386294361
+5.0        5.5 ... 1.609437912
+6.0 6.61234567 ... 1.791759469
+`);
+
+    // 4
+    expect(df.toString({maxColumns: 4}))
+      .toEqual(
+        `\
+  a          b    c           d
+0.0        0.0  foo        -Inf
+1.0        1.1 null         0.0
+2.0        2.2 null 0.693147181
+3.0        3.3  bar 1.098612289
+4.0        4.4  baz 1.386294361
+5.0        5.5 null 1.609437912
+6.0 6.61234567  ... 1.791759469
+`);
+
+    // 5 (+1)
+    expect(df.toString({maxColumns: 5}))
+      .toEqual(
+        `\
+  a          b    c           d
+0.0        0.0  foo        -Inf
+1.0        1.1 null         0.0
+2.0        2.2 null 0.693147181
+3.0        3.3  bar 1.098612289
+4.0        4.4  baz 1.386294361
+5.0        5.5 null 1.609437912
+6.0 6.61234567  ... 1.791759469
+`);
+  });
+
+  test('exceeds maxRows and maxCols', () => {
+    const df = new DataFrame({'a': a, 'b': b, 'c': c, 'd': d});
+    expect(df.toString({maxColumns: 3, maxRows: 4}))
+      .toEqual(
+        `\
+  a          b               d
+0.0        0.0 ...        -Inf
+...        ... ...         ...
+6.0 6.61234567 ... 1.791759469
+`);
+  });
+
+  test('maxRows=0', () => {
+    const a  = Series.sequence({type: new Int32, size: 5000, step: 1, init: 0});
+    const df = new DataFrame({'a': a});
+    expect(df.toString({maxRows: 0}).split('\n').length)
+      .toEqual(5002);  // header + trailing newline
+  });
+
+  test('maxColumns=0', () => {
+    const a         = Series.new([0, 1]);
+    const cols: any = {};
+    for (let i = 0; i < 30; ++i) { cols[`a${i}`] = a; }
+    const df = new DataFrame(cols);
+    expect(df.toString({maxColumns: 30, width: 200}))
+      .toEqual(
+        `\
+ a0  a1  a2  a3  a4  a5  a6  a7  a8  a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29
+0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
+1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0
+`);
+  });
+});

--- a/modules/cudf/test/dataframe/print-tests.ts
+++ b/modules/cudf/test/dataframe/print-tests.ts
@@ -87,7 +87,7 @@ null
   });
 
   test('exceeds width', () => {
-    expect(new DataFrame({'a': a, 'b': b, 'c': c, 'd': d}).toString({maxColWidth: 70}))
+    expect(new DataFrame({'a': a, 'b': b, 'c': c, 'd': d}).toString({maxColWidth: 70, width: 80}))
       .toEqual(
         `\
   a          b               d
@@ -274,7 +274,7 @@ null
     const cols: any = {};
     for (let i = 0; i < 30; ++i) { cols[`a${i}`] = a; }
     const df = new DataFrame(cols);
-    expect(df.toString({maxColumns: 30, width: 200}))
+    expect(df.toString({maxColumns: 30}))
       .toEqual(
         `\
  a0  a1  a2  a3  a4  a5  a6  a7  a8  a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29


### PR DESCRIPTION
Adds basic pretty-printing method to `DataFrame` e.g.

```
> console.log(new DataFrame({'a': a, 'b': b, 'c': c, 'd': d}).toString({maxColWidth: 70}))
  a          b               d
0.0        0.0 ...        -Inf
1.0        1.1 ...         0.0
2.0        2.2 ... 0.693147181
3.0        3.3 ... 1.098612289
4.0        4.4 ... 1.386294361
5.0        5.5 ... 1.609437912
6.0 6.61234567 ... 1.791759469
```

Supports options:
* `maxColumns`
* `maxColWidth`
* `maxRows`
* `width`

Lots of corner cases and "fix one test break another" but I think this is at a good starting point. 