### PR TITLE
Add StringSeries.concatenate

### DIFF
--- a/modules/cudf/src/column.cpp
+++ b/modules/cudf/src/column.cpp
@@ -101,8 +101,6 @@ Napi::Function Column::Init(Napi::Env const& env, Napi::Object exports) {
                        InstanceMethod<&Column::cumulative_min>("cumulativeMin"),
                        InstanceMethod<&Column::cumulative_product>("cumulativeProduct"),
                        InstanceMethod<&Column::cumulative_sum>("cumulativeSum"),
-                       // column/strings/json.cpp
-                       InstanceMethod<&Column::get_json_object>("getJSONObject"),
                        // column/replacement.cpp
                        InstanceMethod<&Column::replace_nulls>("replaceNulls"),
                        InstanceMethod<&Column::replace_nans>("replaceNaNs"),
@@ -137,10 +135,14 @@ Napi::Function Column::Init(Napi::Env const& env, Napi::Object exports) {
                        // column/strings/attributes.cpp
                        InstanceMethod<&Column::count_bytes>("countBytes"),
                        InstanceMethod<&Column::count_characters>("countCharacters"),
+                       // column/strings/combine.cpp
+                       StaticMethod<&Column::concatenate>("concatenate"),
                        // column/strings/contains.cpp
                        InstanceMethod<&Column::contains_re>("containsRe"),
                        InstanceMethod<&Column::count_re>("countRe"),
                        InstanceMethod<&Column::matches_re>("matchesRe"),
+                       // column/strings/json.cpp
+                       InstanceMethod<&Column::get_json_object>("getJSONObject"),
                        // column/strings/padding.cpp
                        InstanceMethod<&Column::pad>("pad"),
                        InstanceMethod<&Column::zfill>("zfill"),

--- a/modules/cudf/src/column.ts
+++ b/modules/cudf/src/column.ts
@@ -17,6 +17,7 @@ import {DeviceBuffer, MemoryResource} from '@rapidsai/rmm';
 
 import CUDF from './addon';
 import {Scalar} from './scalar';
+import {Table} from './table';
 import {
   Bool8,
   DataType,
@@ -75,6 +76,25 @@ export type ColumnProps<T extends DataType = any> = {
 interface ColumnConstructor {
   readonly prototype: Column;
   new<T extends DataType = any>(props: ColumnProps<T>): Column<T>;
+
+  /**
+   * Row-wise concatenates the given list of strings columns and returns a single strings column
+   * result.
+   *
+   * @param columns List of string columns to concatenate.
+   * @param separator String that should inserted between each string from each row.
+   * @param narep String that should be used in place of any null strings found in any column.
+   *   Null value means any null entry in any column will produces a null result for that row.
+   * @param separate_nulls If true, then the separator is included for null rows if narep is valid.
+   * @param memoryResource The optional MemoryResource used to allocate the result column's device
+   *   memory
+   * @returns New column with concatenated results.
+   */
+  concatenate(columns: Table,
+              separator: string,
+              narep: string|null,
+              separate_nulls: boolean,
+              memoryResource?: MemoryResource): Column<Utf8String>;
 
   /**
    * Fills a column with a sequence of values specified by an initial value and a step of 1.

--- a/modules/cudf/src/column/strings/combine.cpp
+++ b/modules/cudf/src/column/strings/combine.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <node_cudf/column.hpp>
+#include <node_cudf/scalar.hpp>
+#include <node_cudf/table.hpp>
+
+#include <node_rmm/device_buffer.hpp>
+
+#include <cudf/column/column.hpp>
+#include <cudf/strings/combine.hpp>
+#include <cudf/types.hpp>
+#include <rmm/device_buffer.hpp>
+#include "cudf/scalar/scalar.hpp"
+#include "cudf/table/table_view.hpp"
+
+#include <napi.h>
+
+namespace nv {
+
+Column::wrapper_t Column::concatenate(Napi::Env const& env,
+                                      cudf::table_view const& columns,
+                                      cudf::string_scalar const& separator,
+                                      cudf::string_scalar const& narep,
+                                      cudf::strings::separator_on_nulls separator_on_nulls,
+                                      rmm::mr::device_memory_resource* mr) {
+  try {
+    return Column::New(
+      env, cudf::strings::concatenate(columns, separator, narep, separator_on_nulls, mr));
+  } catch (cudf::logic_error const& err) { NAPI_THROW(Napi::Error::New(env, err.what())); }
+}
+
+Napi::Value Column::concatenate(Napi::CallbackInfo const& info) {
+  CallbackArgs args{info};
+
+  if (args.Length() != 5) {
+    NAPI_THROW(Napi::Error::New(info.Env(),
+                                "concatenate expects a columns, separator, narep, "
+                                "separator_on_nulls and optionally a memory resource"));
+  }
+
+  Table::wrapper_t columns            = args[0];
+  const std::string& separator_string = args[1];
+  const cudf::string_scalar separator{separator_string};
+
+  auto narep = [&args]() {
+    if (args[2].IsNull()) {
+      return cudf::string_scalar{"", false};
+    } else {
+      const std::string& narep_string = args[2];
+      return cudf::string_scalar{narep_string};
+    }
+  }();
+
+  auto separator_on_nulls = [&args]() {
+    bool separator_on_nulls_bool = args[3];
+    return separator_on_nulls_bool ? cudf::strings::separator_on_nulls::YES
+                                   : cudf::strings::separator_on_nulls::NO;
+  }();
+
+  rmm::mr::device_memory_resource* mr = args[4];
+
+  return concatenate(info.Env(), columns->view(), separator, narep, separator_on_nulls, mr);
+}
+
+}  // namespace nv

--- a/modules/cudf/src/node_cudf/column.hpp
+++ b/modules/cudf/src/node_cudf/column.hpp
@@ -28,6 +28,7 @@
 #include <cudf/copying.hpp>
 #include <cudf/replace.hpp>
 #include <cudf/stream_compaction.hpp>
+#include <cudf/strings/combine.hpp>
 #include <cudf/strings/padding.hpp>
 #include <cudf/types.hpp>
 #include <cudf/unary.hpp>
@@ -654,11 +655,6 @@ struct Column : public EnvLocalObjectWrap<Column> {
     cudf::scalar const& value,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
-  // column/strings/json.cpp
-  Column::wrapper_t get_json_object(
-    std::string const& json_path,
-    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
-
   // column/replace.cpp
   Column::wrapper_t replace_nulls(
     cudf::column_view const& replacement,
@@ -708,6 +704,15 @@ struct Column : public EnvLocalObjectWrap<Column> {
   Column::wrapper_t count_characters(
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
+  // column/strings/combine.cpp
+  static Column::wrapper_t concatenate(
+    Napi::Env const& env,
+    cudf::table_view const& columns,
+    cudf::string_scalar const& separator,
+    cudf::string_scalar const& narep,
+    cudf::strings::separator_on_nulls separator_on_nulls,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
   // column/strings/contains.cpp
   Column::wrapper_t contains_re(
     std::string const& pattern,
@@ -720,6 +725,11 @@ struct Column : public EnvLocalObjectWrap<Column> {
   Column::wrapper_t matches_re(
     std::string const& pattern,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
+  // column/strings/json.cpp
+  Column::wrapper_t get_json_object(
+    std::string const& json_path,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   // column/strings/padding.cpp
   Column::wrapper_t pad(
@@ -853,9 +863,6 @@ struct Column : public EnvLocalObjectWrap<Column> {
   Napi::Value cumulative_product(Napi::CallbackInfo const& info);
   Napi::Value cumulative_sum(Napi::CallbackInfo const& info);
 
-  // column/strings/json.cpp
-  Napi::Value get_json_object(Napi::CallbackInfo const& info);
-
   // column/replace.cpp
   Napi::Value replace_nulls(Napi::CallbackInfo const& info);
   Napi::Value replace_nans(Napi::CallbackInfo const& info);
@@ -893,10 +900,16 @@ struct Column : public EnvLocalObjectWrap<Column> {
   Napi::Value count_bytes(Napi::CallbackInfo const& info);
   Napi::Value count_characters(Napi::CallbackInfo const& info);
 
+  // column/filling.cpp
+  static Napi::Value concatenate(Napi::CallbackInfo const& info);
+
   // column/strings/contains.cpp
   Napi::Value contains_re(Napi::CallbackInfo const& info);
   Napi::Value count_re(Napi::CallbackInfo const& info);
   Napi::Value matches_re(Napi::CallbackInfo const& info);
+
+  // column/strings/json.cpp
+  Napi::Value get_json_object(Napi::CallbackInfo const& info);
 
   // column/strings/padding.cpp
   Napi::Value pad(Napi::CallbackInfo const& info);

--- a/modules/cudf/test/series/string-tests.ts
+++ b/modules/cudf/test/series/string-tests.ts
@@ -66,6 +66,45 @@ describe('StringSeries', () => {
   });
 });
 
+describe('StringSeries.concatenate', () => {
+  const s = StringSeries.new(['a', 'b', null]);
+  const t = StringSeries.new(['foo', null, 'bar']);
+
+  test('basic (no opts)', () => {
+    const result = StringSeries.concatenate([s, t]);
+    expect([...result]).toEqual(['afoo', null, null]);
+  });
+  test('basic (repeat)', () => {
+    const result = StringSeries.concatenate([s, t, s, t]);
+    expect([...result]).toEqual(['afooafoo', null, null]);
+  });
+  test('basic (empty opts)', () => {
+    const result = StringSeries.concatenate([s, t], {});
+    expect([...result]).toEqual(['afoo', null, null]);
+  });
+  test('separator', () => {
+    const result = StringSeries.concatenate([s, t], {separator: '::'});
+    expect([...result]).toEqual(['a::foo', null, null]);
+  });
+  test('separator (repeat)', () => {
+    const result = StringSeries.concatenate([s, t, s], {separator: '::'});
+    expect([...result]).toEqual(['a::foo::a', null, null]);
+  });
+  test('narep (no separator)', () => {
+    const result = StringSeries.concatenate([s, t], {narep: 'null'});
+    expect([...result]).toEqual(['afoo', 'bnull', 'nullbar']);
+  });
+  test('narep (separator)', () => {
+    const result = StringSeries.concatenate([s, t], {separator: '::', narep: 'null'});
+    expect([...result]).toEqual(['a::foo', 'b::null', 'null::bar']);
+  });
+  test('narep (separatorOnNulls)', () => {
+    const result =
+      StringSeries.concatenate([s, t], {separator: '::', narep: 'null', separatorOnNulls: false});
+    expect([...result]).toEqual(['a::foo', 'bnull', 'nullbar']);
+  });
+});
+
 describe.each([['foo'], [/foo/], [/foo/ig]])('Series regex search (pattern=%p)', (pattern) => {
   test('containsRe', () => {
     const expected = [true, true, true, true, true, false, false, true, true];


### PR DESCRIPTION
Pre-req for hypergraph implementation.

The Python "counterpart" for this would be `__add__` which does not exist on the JS side, so I have simply mirrored the `cudf::strings::concatenate` API from libcudf. Open to suggestion for better naming since there is already, e.g. `concat` for other things. 