### PR TITLE
[FIX] allow `blazingsql-io` to link to `arrow_dataset` targets

### DIFF
--- a/modules/core/cmake/Modules/ConfigureBlazingSQL.cmake
+++ b/modules/core/cmake/Modules/ConfigureBlazingSQL.cmake
@@ -20,14 +20,6 @@ function(find_and_configure_blazingsql VERSION)
 
     include(ConfigureCUDF)
 
-    if (TARGET cudf::arrow_shared AND (NOT TARGET arrow_shared))
-        add_library(arrow_shared ALIAS cudf::arrow_shared)
-    endif()
-
-    if (TARGET cudf::arrow_cuda_shared AND (NOT TARGET arrow_cuda_shared))
-        add_library(arrow_cuda_shared ALIAS cudf::arrow_cuda_shared)
-    endif()
-
     _clean_build_dirs_if_not_fully_built(blazingsql-io libblazingsql-io.so)
 
     _set_package_dir_if_exists(absl absl)

--- a/modules/core/cmake/Modules/ConfigureCUDF.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUDF.cmake
@@ -39,8 +39,10 @@ function(find_and_configure_cudf VERSION)
         _get_update_disconnected_state(cudf ${VERSION} UPDATE_DISCONNECTED)
         CPMFindPackage(NAME     cudf
             VERSION             ${VERSION}
-            GIT_REPOSITORY      https://github.com/rapidsai/cudf.git
-            GIT_TAG             branch-${MAJOR_AND_MINOR}
+            # GIT_REPOSITORY      https://github.com/rapidsai/cudf.git
+            # GIT_TAG             branch-${MAJOR_AND_MINOR}
+            GIT_REPOSITORY      https://github.com/trxcllnt/cudf.git
+            GIT_TAG             fix/arrow-parquet-targets
             GIT_SHALLOW         TRUE
             ${UPDATE_DISCONNECTED}
             SOURCE_SUBDIR       cpp


### PR DESCRIPTION
Use the branch in [this PR](https://github.com/rapidsai/cudf/pull/9491) to fix missing parquet symbols in `blazingsql-io`.