### PR TITLE
[FIX] set `<pkg>_ROOT` instead of `<pkg>_DIR` to work around rapids-cmake libcudacxx issue

### DIFF
--- a/modules/core/cmake/Modules/ConfigureCUDF.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUDF.cmake
@@ -25,8 +25,8 @@ function(find_and_configure_cudf VERSION)
     _set_package_dir_if_exists(cudf cudf)
     _set_package_dir_if_exists(dlpack dlpack)
     _set_package_dir_if_exists(jitify jitify)
+    _set_package_dir_if_exists(nvcomp nvcomp)
     _set_package_dir_if_exists(Thrust thrust)
-    _set_package_dir_if_exists(libcudacxx libcudacxx)
 
     # Set this so Arrow doesn't add `-Werror` to
     # CMAKE_CXX_FLAGS when CMAKE_BUILD_TYPE=Debug

--- a/modules/core/cmake/Modules/ConfigureRAFT.cmake
+++ b/modules/core/cmake/Modules/ConfigureRAFT.cmake
@@ -27,7 +27,6 @@ function(find_and_configure_raft VERSION)
     _set_package_dir_if_exists(nccl nccl)
     _set_package_dir_if_exists(faiss faiss)
     _set_package_dir_if_exists(Thrust thrust)
-    _set_package_dir_if_exists(libcudacxx libcudacxx)
 
     if(NOT TARGET raft::raft)
         _get_major_minor_version(${VERSION} MAJOR_AND_MINOR)

--- a/modules/core/cmake/Modules/get_cpm.cmake
+++ b/modules/core/cmake/Modules/get_cpm.cmake
@@ -54,7 +54,7 @@ if (NOT DEFINED ENV{NODE_RAPIDS_USE_LOCAL_DEPS_BUILD_DIRS})
     set(FETCHCONTENT_BASE_DIR "${CPM_BINARY_CACHE}" CACHE STRING "" FORCE)
 endif()
 
-set(CPM_DOWNLOAD_VERSION 7644c3a40fc7889f8dee53ce21e85dc390b883dc) # v0.32.1
+set(CPM_DOWNLOAD_VERSION 634800c61928d330a6e9559171509a5c3dd479d5) # 0.34.0
 
 if(CPM_SOURCE_CACHE)
   # Expand relative path. This is important if the provided path contains a tilde (~)
@@ -79,10 +79,10 @@ include(${CPM_DOWNLOAD_LOCATION})
 function(_set_package_dir_if_exists pkg dir)
     if (NOT DEFINED ENV{NODE_RAPIDS_USE_LOCAL_DEPS_BUILD_DIRS})
         if (EXISTS "${CPM_BINARY_CACHE}/${dir}-build")
-            message(STATUS "get_cpm: setting ${pkg}_DIR to '${CPM_BINARY_CACHE}/${dir}-build'")
-            set(${pkg}_DIR "${CPM_BINARY_CACHE}/${dir}-build" PARENT_SCOPE)
+            message(STATUS "get_cpm: setting ${pkg}_ROOT to '${CPM_BINARY_CACHE}/${dir}-build'")
+            set(${pkg}_ROOT "${CPM_BINARY_CACHE}/${dir}-build" PARENT_SCOPE)
         else()
-            message(STATUS "get_cpm: not setting ${pkg}_DIR because '${CPM_BINARY_CACHE}/${dir}-build' does not exist")
+            message(STATUS "get_cpm: not setting ${pkg}_ROOT because '${CPM_BINARY_CACHE}/${dir}-build' does not exist")
         endif()
     endif()
 endfunction()

--- a/modules/cudf/src/column/strings/contains.cpp
+++ b/modules/cudf/src/column/strings/contains.cpp
@@ -25,21 +25,27 @@ namespace nv {
 Column::wrapper_t Column::contains_re(std::string const& pattern,
                                       rmm::mr::device_memory_resource* mr) const {
   try {
-    return Column::New(Env(), cudf::strings::contains_re(this->view(), pattern, mr));
+    return Column::New(
+      Env(),
+      cudf::strings::contains_re(this->view(), pattern, cudf::strings::regex_flags::DEFAULT, mr));
   } catch (cudf::logic_error const& err) { NAPI_THROW(Napi::Error::New(Env(), err.what())); }
 }
 
 Column::wrapper_t Column::count_re(std::string const& pattern,
                                    rmm::mr::device_memory_resource* mr) const {
   try {
-    return Column::New(Env(), cudf::strings::count_re(this->view(), pattern, mr));
+    return Column::New(
+      Env(),
+      cudf::strings::count_re(this->view(), pattern, cudf::strings::regex_flags::DEFAULT, mr));
   } catch (cudf::logic_error const& err) { NAPI_THROW(Napi::Error::New(Env(), err.what())); }
 }
 
 Column::wrapper_t Column::matches_re(std::string const& pattern,
                                      rmm::mr::device_memory_resource* mr) const {
   try {
-    return Column::New(Env(), cudf::strings::matches_re(this->view(), pattern, mr));
+    return Column::New(
+      Env(),
+      cudf::strings::matches_re(this->view(), pattern, cudf::strings::regex_flags::DEFAULT, mr));
   } catch (cudf::logic_error const& err) { NAPI_THROW(Napi::Error::New(Env(), err.what())); }
 }
 


### PR DESCRIPTION
Fixes the build for the latest versions of RAPIDS dependencies.