### PR TITLE
add Column.replaceSlice

### DIFF
--- a/modules/cudf/src/column.cpp
+++ b/modules/cudf/src/column.cpp
@@ -146,6 +146,8 @@ Napi::Function Column::Init(Napi::Env const& env, Napi::Object exports) {
                        // column/strings/padding.cpp
                        InstanceMethod<&Column::pad>("pad"),
                        InstanceMethod<&Column::zfill>("zfill"),
+                       // column/strings/replace.cpp
+                       InstanceMethod<&Column::replace_slice>("replaceSlice"),
                        // column/convert.cpp
                        InstanceMethod<&Column::strings_from_booleans>("stringsFromBooleans"),
                        InstanceMethod<&Column::strings_to_booleans>("stringsToBooleans"),

--- a/modules/cudf/src/column.ts
+++ b/modules/cudf/src/column.ts
@@ -1282,6 +1282,29 @@ export interface Column<T extends DataType = any> {
    * @returns New column of strings.
    */
   zfill(width: number, memoryResource?: MemoryResource): Column<Utf8String>;
+
+  /**
+   * Replaces each string in the column with the provided repl string within the [start,stop)
+   * character position range.
+   *
+   * Null string entries will return null output string entries.
+   *
+   * Position values are 0-based meaning position 0 is the first character of each string.
+   *
+   * This function can be used to insert a string into specific position by specifying the same
+   * position value for start and stop. The repl string can be appended to each string by specifying
+   * -1 for both start and stop.
+   *
+   * @param repl Replacement string for specified positions found.
+   * @param start Start position where repl will be added. Default is 0, first character position.
+   * @param stop End position (exclusive) to use for replacement. Default of -1 specifies the end of
+   *   each string.
+   * @param memoryResource The optional MemoryResource used to allocate the result Column's device
+   *   memory.
+   * @returns New strings column
+   */
+  replaceSlice(repl: string, start: number, stop: number, memoryResource?: MemoryResource):
+    Column<Utf8String>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/modules/cudf/src/column/strings/replace.cpp
+++ b/modules/cudf/src/column/strings/replace.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <node_cudf/column.hpp>
+#include <node_cudf/utilities/napi_to_cpp.hpp>
+
+#include <node_rmm/memory_resource.hpp>
+
+#include <cudf/strings/replace.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+
+namespace nv {
+
+Column::wrapper_t Column::replace_slice(std::string const& repl,
+                                        cudf::size_type start,
+                                        cudf::size_type stop,
+                                        rmm::mr::device_memory_resource* mr) const {
+  try {
+    return Column::New(Env(), cudf::strings::replace_slice(this->view(), repl, start, stop, mr));
+  } catch (cudf::logic_error const& err) { NAPI_THROW(Napi::Error::New(Env(), err.what())); }
+}
+
+Napi::Value Column::replace_slice(Napi::CallbackInfo const& info) {
+  if (info.Length() < 3) {
+    NODE_CUDF_THROW(
+      "Column replace_slice expects a replacement, start, stop, and optional MemoryResource",
+      info.Env());
+  }
+  CallbackArgs const args{info};
+
+  return replace_slice(args[0], args[1], args[2], args[3]);
+}
+
+}  // namespace nv

--- a/modules/cudf/src/node_cudf/column.hpp
+++ b/modules/cudf/src/node_cudf/column.hpp
@@ -742,6 +742,13 @@ struct Column : public EnvLocalObjectWrap<Column> {
     cudf::size_type width,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
+  // column/strings/replace_slice.cpp
+  Column::wrapper_t replace_slice(
+    std::string const& repl             = "",
+    cudf::size_type start               = 0,
+    cudf::size_type stop                = -1,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
   // column/convert.cpp
 
   Column::wrapper_t strings_from_booleans(
@@ -921,6 +928,9 @@ struct Column : public EnvLocalObjectWrap<Column> {
   // column/strings/padding.cpp
   Napi::Value pad(Napi::CallbackInfo const& info);
   Napi::Value zfill(Napi::CallbackInfo const& info);
+
+  // column/strings/replace.cpp
+  Napi::Value replace_slice(Napi::CallbackInfo const& info);
 
   // column/convert.hpp
   Napi::Value strings_from_booleans(Napi::CallbackInfo const& info);

--- a/modules/cudf/test/cudf-column-tests.ts
+++ b/modules/cudf/test/cudf-column-tests.ts
@@ -206,6 +206,39 @@ test('Column.stringsToIntegers', () => {
   expect([...Series.new(result)]).toEqual(expected);
 });
 
+describe('Column.replaceSlice', () => {
+  test('prepend', () => {
+    const col      = Series.new(['foo', 'bar', 'abcdef'])._col;
+    const result   = col.replaceSlice('123', 0, 0);
+    const expected = ['123foo', '123bar', '123abcdef'];
+    expect([...Series.new(result)]).toEqual(expected);
+  });
+  test('append', () => {
+    const col      = Series.new(['foo', 'bar', 'abcdef'])._col;
+    const result   = col.replaceSlice('123', -1, -1);
+    const expected = ['foo123', 'bar123', 'abcdef123'];
+    expect([...Series.new(result)]).toEqual(expected);
+  });
+  test('insert', () => {
+    const col      = Series.new(['foo', 'bar', 'abcdef'])._col;
+    const result   = col.replaceSlice('123', 1, 1);
+    const expected = ['f123oo', 'b123ar', 'a123bcdef'];
+    expect([...Series.new(result)]).toEqual(expected);
+  });
+  test('replace middle', () => {
+    const col      = Series.new(['foo', 'bar', 'abcdef'])._col;
+    const result   = col.replaceSlice('123', 1, 2);
+    const expected = ['f123o', 'b123r', 'a123cdef'];
+    expect([...Series.new(result)]).toEqual(expected);
+  });
+  test('replace entire', () => {
+    const col      = Series.new(['foo', 'bar', 'abcdef'])._col;
+    const result   = col.replaceSlice('123', 0, -1);
+    const expected = ['123', '123', '123'];
+    expect([...Series.new(result)]).toEqual(expected);
+  });
+});
+
 describe('Column.setNullMask', () => {
   const arange = (length: number) => Array.from({length}, (_, i) => i);
   const makeTestColumn            = (length: number) =>


### PR DESCRIPTION
Quick stepping stone PR adds `Column.replaceSlice` that will later be used to implement categorical metadata support in CuGraph `hypergraph`