### PR TITLE
[FIX] Update to CUDA 11.5, RAPIDS 22.02, node 16.13.0

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,14 +6,14 @@ UID=1000
 # more memory.
 PARALLEL_LEVEL=4
 
-# `nvidia/cudagl` base image CUDA version
-# CUDA_VERSION=11.4.2
+# `nvidia/cuda` base image CUDA version
+# CUDA_VERSION=11.5.0
 
-# `nvidia/cudagl` base image Ubuntu version
+# `nvidia/cuda` base image Ubuntu version
 # LINUX_VERSION=ubuntu20.04
 
 # RAPIDS version to use
-# RAPIDS_VERSION=21.12.00
+# RAPIDS_VERSION=22.02.00
 
 # How long sccache should wait until it considers a compile job timed out.
 # This number should be large, because C++ and CUDA can take a long time to compile.

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,7 @@ jobs:
   update:
     name: Update Docs
     runs-on: ubuntu-20.04
-    container: node:16.10.0-buster
+    container: node:16.13.0-buster
     steps:
       - name: Checkout main
         uses: actions/checkout@v2

--- a/.github/workflows/main.pr.yml
+++ b/.github/workflows/main.pr.yml
@@ -12,15 +12,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        include:
-          - CUDA: 11.0.3
-            LINUX: ubuntu18.04
-          - CUDA: 11.4.2
-            LINUX: ubuntu20.04
+        CUDA: [11.5.0]
+        LINUX: [ubuntu18.04, ubuntu20.04]
     env:
-      ARCH: amd64
-      NODE: 16.10.0
-      RAPIDS: 21.12.00
+      NODE: 16.13.0
+      RAPIDS: 22.02.00
       REPOSITORY: ghcr.io/rapidsai/node
     steps:
       - name: Checkout
@@ -44,13 +40,13 @@ jobs:
       - name: Cache C++ dependencies
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ env.RAPIDS }}-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-${{ env.ARCH }}-cache-${{ hashFiles('**/modules/**/CMakeLists.txt', '**/modules/**/*.cmake') }}
+          key: ${{ runner.os }}-${{ env.RAPIDS }}-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-cache-${{ hashFiles('**/modules/**/CMakeLists.txt', '**/modules/**/*.cmake') }}
           path: |
             .cache
       - name: Cache node_modules
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ env.RAPIDS }}-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-${{ env.ARCH }}-node_modules-${{ hashFiles('**/yarn.lock', '**/package.json') }}
+          key: ${{ runner.os }}-${{ env.RAPIDS }}-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-node_modules-${{ hashFiles('**/yarn.lock', '**/package.json') }}
           path: |
             node_modules
       - name: Check if devel dockerfiles changed
@@ -61,7 +57,6 @@ jobs:
             dockerfiles/devel/main.Dockerfile
       - name: Build devel images and packages
         run: |
-          echo "ARCH=${{ env.ARCH }}" >> .env
           echo "CUDAARCHS=ALL" >> .env
           echo "PARALLEL_LEVEL=1" >> .env
           echo "REPOSITORY=${{ env.REPOSITORY }}" >> .env
@@ -79,7 +74,12 @@ jobs:
           fi
           mkdir -p /tmp/.{yarn,cache}
           docker run --rm \
-            -u "$(id -u):$(id -g)" -v "$(pwd):/opt/rapids/node:rw" -v "/tmp/.yarn:/.yarn:rw" -v "/tmp/.cache:/.cache:rw" \
-            --env-file .env -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
-            ${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }} \
+            --env-file .env \
+            -u "$(id -u):$(id -g)" \
+            -v "/tmp/.yarn:/.yarn:rw" \
+            -v "/tmp/.cache:/.cache:rw" \
+            -v "$(pwd):/opt/rapids/node:rw" \
+            -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
+            -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+            ${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-main \
             bash -c 'set -ex; echo $PATH && echo $CUDA_HOME && which -a nvcc && nvcc --version && yarn && yarn rebuild'

--- a/.github/workflows/merge.pr.yml
+++ b/.github/workflows/merge.pr.yml
@@ -6,9 +6,9 @@ on:
       - main
 
 env:
-  ARCH: amd64
-  NODE: 16.10.0
-  RAPIDS: 21.12.00
+  NODE: 16.13.0
+  RAPIDS: 22.02.00
+  REPOSITORY: ghcr.io/rapidsai/node
 
 concurrency:
   group: build_docker_images
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        CUDA: [11.0.3, 11.2.2, 11.4.2]
+        CUDA: [11.5.0]
         LINUX: [ubuntu18.04, ubuntu20.04]
     steps:
       - uses: actions/checkout@v2
@@ -49,13 +49,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           file: dockerfiles/devel/main.Dockerfile
           tags: |
-            ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }}
+            ${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-main
           build-args: |
             "NODE_VERSION=${{ env.NODE }}"
             "SCCACHE_IDLE_TIMEOUT=32768"
             "SCCACHE_REGION=us-west-2"
             "SCCACHE_BUCKET=node-rapids-sccache"
-            "FROM_IMAGE=nvidia/cudagl:${{ matrix.CUDA }}-devel-${{ matrix.LINUX }}"
+            "FROM_IMAGE=gpuci/cuda:${{ matrix.CUDA }}-devel-${{ matrix.LINUX }}"
 
   build-and-publish-devel-packages-image:
     needs:
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        CUDA: [11.0.3, 11.2.2, 11.4.2]
+        CUDA: [11.5.0]
         LINUX: [ubuntu18.04, ubuntu20.04]
     steps:
       - uses: actions/checkout@v2
@@ -96,14 +96,14 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           file: dockerfiles/devel/package.Dockerfile
           tags: |
-            ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages-${{ env.ARCH }}
+            ${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages
           build-args: |
             "PARALLEL_LEVEL=1"
             "SCCACHE_IDLE_TIMEOUT=32768"
             "SCCACHE_REGION=us-west-2"
             "SCCACHE_BUCKET=node-rapids-sccache"
             "RAPIDS_VERSION=${{ env.RAPIDS }}"
-            "FROM_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }}"
+            "FROM_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-main"
 
   build-and-publish-runtime-cuda-base-image:
     needs:
@@ -114,49 +114,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        CUDA: [11.0.3, 11.2.2, 11.4.2]
-        LINUX: [ubuntu18.04, ubuntu20.04]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
-      - name: Check if files changed
-        id: files_changed
-        uses: tj-actions/changed-files@v9.1
-        with:
-          files: |
-            dockerfiles/runtime/base.Dockerfile
-            .github/workflows/merge.pr.yml
-            .github/actions/build-and-publish-image/action.yml
-      - name: Build and push image
-        if: ${{ steps.files_changed.outputs.any_changed == 'true' || steps.files_changed.outputs.any_deleted == 'true' }}
-        uses: ./.github/actions/build-and-publish-image
-        with:
-          registry-url: ghcr.io
-          registry-username: ${{ github.repository_owner }}
-          registry-password: ${{ github.token }}
-          pull: true
-          push: ${{ github.event_name == 'push' }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          file: dockerfiles/runtime/base.Dockerfile
-          tags: |
-            ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base-${{ env.ARCH }}
-          build-args: |
-            "UID=1000"
-            "FROM_IMAGE=nvidia/cuda:${{ matrix.CUDA }}-runtime-${{ matrix.LINUX }}"
-            "DEVEL_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }}"
-
-  build-and-publish-runtime-cudagl-base-image:
-    needs:
-      - build-and-publish-devel-main-image
-      - build-and-publish-devel-packages-image
-    name: Build runtime cudagl-base image
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: true
-      matrix:
-        CUDA: [11.0.3, 11.2.2, 11.4.2]
+        CUDA: [11.5.0]
         LINUX: [ubuntu18.04, ubuntu20.04]
     steps:
       - uses: actions/checkout@v2
@@ -183,11 +141,11 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           file: dockerfiles/runtime/base.Dockerfile
           tags: |
-            ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-base-${{ env.ARCH }}
+            ${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base
           build-args: |
             "UID=1000"
-            "FROM_IMAGE=nvidia/cudagl:${{ matrix.CUDA }}-runtime-${{ matrix.LINUX }}"
-            "DEVEL_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }}"
+            "FROM_IMAGE=gpuci/cuda:${{ matrix.CUDA }}-runtime-${{ matrix.LINUX }}"
+            "DEVEL_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-main"
 
   build-and-publish-runtime-cudf-image:
     needs:
@@ -198,7 +156,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        CUDA: [11.0.3, 11.2.2, 11.4.2]
+        CUDA: [11.5.0]
         LINUX: [ubuntu18.04, ubuntu20.04]
     steps:
       - uses: actions/checkout@v2
@@ -227,10 +185,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           file: dockerfiles/runtime/cudf.Dockerfile
           tags: |
-            ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-cudf-${{ env.ARCH }}
+            ${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-cudf
           build-args: |
-            "FROM_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base-${{ env.ARCH }}"
-            "DEVEL_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages-${{ env.ARCH }}"
+            "FROM_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base"
+            "DEVEL_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages"
 
   build-and-publish-runtime-cugraph-image:
     needs:
@@ -241,7 +199,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        CUDA: [11.0.3, 11.2.2, 11.4.2]
+        CUDA: [11.5.0]
         LINUX: [ubuntu18.04, ubuntu20.04]
     steps:
       - uses: actions/checkout@v2
@@ -270,10 +228,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           file: dockerfiles/runtime/cugraph.Dockerfile
           tags: |
-            ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-cugraph-${{ env.ARCH }}
+            ${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-cugraph
           build-args: |
-            "FROM_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base-${{ env.ARCH }}"
-            "DEVEL_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages-${{ env.ARCH }}"
+            "FROM_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base"
+            "DEVEL_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages"
 
   build-and-publish-runtime-cuml-image:
     needs:
@@ -284,7 +242,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        CUDA: [11.0.3, 11.2.2, 11.4.2]
+        CUDA: [11.5.0]
         LINUX: [ubuntu18.04, ubuntu20.04]
     steps:
       - uses: actions/checkout@v2
@@ -313,10 +271,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           file: dockerfiles/runtime/cuml.Dockerfile
           tags: |
-            ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-cuml-${{ env.ARCH }}
+            ${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-cuml
           build-args: |
-            "FROM_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base-${{ env.ARCH }}"
-            "DEVEL_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages-${{ env.ARCH }}"
+            "FROM_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base"
+            "DEVEL_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages"
 
   build-and-publish-runtime-cuspatial-image:
     needs:
@@ -327,7 +285,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        CUDA: [11.0.3, 11.2.2, 11.4.2]
+        CUDA: [11.5.0]
         LINUX: [ubuntu18.04, ubuntu20.04]
     steps:
       - uses: actions/checkout@v2
@@ -356,21 +314,21 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           file: dockerfiles/runtime/cuspatial.Dockerfile
           tags: |
-            ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-cuspatial-${{ env.ARCH }}
+            ${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-cuspatial
           build-args: |
-            "FROM_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base-${{ env.ARCH }}"
-            "DEVEL_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages-${{ env.ARCH }}"
+            "FROM_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base"
+            "DEVEL_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages"
 
   build-and-publish-runtime-glfw-image:
     needs:
       - build-and-publish-devel-packages-image
-      - build-and-publish-runtime-cudagl-base-image
+      - build-and-publish-runtime-cuda-base-image
     name: Build runtime glfw image
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: true
       matrix:
-        CUDA: [11.0.3, 11.2.2, 11.4.2]
+        CUDA: [11.5.0]
         LINUX: [ubuntu18.04, ubuntu20.04]
     steps:
       - uses: actions/checkout@v2
@@ -399,10 +357,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           file: dockerfiles/runtime/glfw.Dockerfile
           tags: |
-            ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-glfw-${{ env.ARCH }}
+            ${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-glfw
           build-args: |
-            "FROM_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-base-${{ env.ARCH }}"
-            "DEVEL_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages-${{ env.ARCH }}"
+            "FROM_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base"
+            "DEVEL_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages"
 
   build-and-publish-runtime-sql-image:
     needs:
@@ -413,7 +371,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        CUDA: [11.0.3, 11.2.2, 11.4.2]
+        CUDA: [11.5.0]
         LINUX: [ubuntu18.04, ubuntu20.04]
     steps:
       - uses: actions/checkout@v2
@@ -442,21 +400,21 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           file: dockerfiles/runtime/sql.Dockerfile
           tags: |
-            ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-sql-${{ env.ARCH }}
+            ${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-sql
           build-args: |
-            "FROM_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base-${{ env.ARCH }}"
-            "DEVEL_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages-${{ env.ARCH }}"
+            "FROM_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base"
+            "DEVEL_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages"
 
   build-and-publish-runtime-main-image:
     needs:
       - build-and-publish-devel-packages-image
-      - build-and-publish-runtime-cudagl-base-image
+      - build-and-publish-runtime-cuda-base-image
     name: Build runtime main image
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: true
       matrix:
-        CUDA: [11.0.3, 11.2.2, 11.4.2]
+        CUDA: [11.5.0]
         LINUX: [ubuntu18.04, ubuntu20.04]
     steps:
       - uses: actions/checkout@v2
@@ -485,21 +443,21 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           file: dockerfiles/runtime/main.Dockerfile
           tags: |
-            ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-main-${{ env.ARCH }}
+            ${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-main
           build-args: |
-            "FROM_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-base-${{ env.ARCH }}"
-            "DEVEL_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages-${{ env.ARCH }}"
+            "FROM_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base"
+            "DEVEL_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages"
 
   build-and-publish-runtime-demo-image:
     needs:
       - build-and-publish-devel-packages-image
-      - build-and-publish-runtime-cudagl-base-image
+      - build-and-publish-runtime-cuda-base-image
     name: Build runtime demo image
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: true
       matrix:
-        CUDA: [11.0.3, 11.2.2, 11.4.2]
+        CUDA: [11.5.0]
         LINUX: [ubuntu18.04, ubuntu20.04]
     steps:
       - uses: actions/checkout@v2
@@ -528,7 +486,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           file: dockerfiles/runtime/demo.Dockerfile
           tags: |
-            ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-demo-${{ env.ARCH }}
+            ${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-demo
           build-args: |
-            "FROM_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-base-${{ env.ARCH }}"
-            "DEVEL_IMAGE=ghcr.io/rapidsai/node:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cudagl${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages-${{ env.ARCH }}"
+            "FROM_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-runtime-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-base"
+            "DEVEL_IMAGE=${{ env.REPOSITORY }}:${{ env.RAPIDS }}-devel-node${{ env.NODE }}-cuda${{ matrix.CUDA }}-${{ matrix.LINUX }}-packages"

--- a/USAGE.md
+++ b/USAGE.md
@@ -11,12 +11,12 @@
 
 We publish standalone docker images [to the `rapidsai/node` repository](https://github.com/orgs/rapidsai/packages/container/package/node) to the GitHub container registry on each PR merge.
 
-These images are based on the [`nvidia/cuda`](https://hub.docker.com/r/nvidia/cuda) and [`nvidia/cudagl`](https://hub.docker.com/r/nvidia/cudagl) runtime images. They are intended to be used directly, extended with app code, or to serve as examples for building your own deployment images. The sources for each image are in [dockerfiles/runtime](https://github.com/rapidsai/node/tree/main/dockerfiles/runtime).
+These images are based on the [`nvidia/cuda`](https://hub.docker.com/r/nvidia/cuda) runtime image. They are intended to be used directly, extended with app code, or to serve as examples for building your own deployment images. The sources for each image are in [dockerfiles/runtime](https://github.com/rapidsai/node/tree/main/dockerfiles/runtime).
 
 Our tag template scheme is as follows:
 
 ```txt
-ghcr.io/rapidsai/node:{{ RAPIDS_VERSION }}-runtime-node{{ NODE_VERSION }}-(cuda|cudagl){{ CUDA_VERSION }}-ubuntu{{ UBUNTU_VERSION }}-{{ LIBRARY_NAME }}-{{ TARGETARCH }}
+ghcr.io/rapidsai/node:{{ RAPIDS_VERSION }}-runtime-node{{ NODE_VERSION }}-cuda{{ CUDA_VERSION }}-ubuntu{{ UBUNTU_VERSION }}-{{ LIBRARY_NAME }}
 ```
 
 The latest manifest is available at the [GitHub container registry page](https://github.com/orgs/rapidsai/packages/container/package/node).
@@ -28,14 +28,13 @@ The following will retrieve the docker image with each library (+ its native and
 ```bash
 REPO=ghcr.io/rapidsai/node
 
-VERSIONS="21.12.00-runtime-node16.10.0-cuda11.4.2-ubuntu20.04"
+VERSIONS="22.02.00-runtime-node16.13.0-cuda11.5.0-ubuntu20.04"
 docker pull $REPO:$VERSIONS-cudf-amd64
 docker pull $REPO:$VERSIONS-cuml-amd64
 docker pull $REPO:$VERSIONS-cugraph-amd64
 docker pull $REPO:$VERSIONS-cuspatial-amd64
 
-# Note the switch from `cuda` to `cudagl`
-VERSIONS="21.12.00-runtime-node16.10.0-cudagl11.4.2-ubuntu20.04"
+VERSIONS="22.02.00-runtime-node16.13.0-cuda11.5.0-ubuntu20.04"
 docker pull $REPO:$VERSIONS-glfw-amd64
 
 # Includes all the above RAPIDS libraries in a single image
@@ -51,7 +50,7 @@ Like the official node images, the default command in the runtime images is `nod
 
 ```bash
 REPO=ghcr.io/rapidsai/node
-VERSIONS="21.12.00-runtime-node16.10.0-cuda11.4.2-ubuntu20.04"
+VERSIONS="22.02.00-runtime-node16.13.0-cuda11.5.0-ubuntu20.04"
 
 # Be sure to pass either the `--runtime=nvidia` or `--gpus` flag!
 docker run --rm --gpus=0 $REPO:$VERSIONS-cudf-amd64 \
@@ -68,7 +67,7 @@ You can mount your host's X11 socket and `$DISPLAY` envvar, then launch demos th
 
 ```bash
 REPO=ghcr.io/rapidsai/node
-VERSIONS="21.12.00-runtime-node16.10.0-cudagl11.4.2-ubuntu20.04"
+VERSIONS="22.02.00-runtime-node16.13.0-cuda11.5.0-ubuntu20.04"
 
 # Be sure to pass either the `--runtime=nvidia` or `--gpus` flag!
 docker run --rm \
@@ -95,7 +94,7 @@ You can use the following technique to install the npm-packed modules into anoth
 
 ```bash
 REPO=ghcr.io/rapidsai/node
-VERSIONS="21.12.00-devel-node16.10.0-cudagl11.4.2-ubuntu20.04"
+VERSIONS="22.02.00-devel-node16.13.0-cuda11.5.0-ubuntu20.04"
 
 # Pull the latest image of the packaged .tgz artifacts
 docker pull $REPO:$VERSIONS-packages-amd64

--- a/docker-compose.devel.yml
+++ b/docker-compose.devel.yml
@@ -49,15 +49,15 @@ services:
 
   main:
     <<: *main_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-devel-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-main-${ARCH:-amd64}
+    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-devel-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-main
     build:
       <<: *base_build_settings
       dockerfile: dockerfiles/devel/main.Dockerfile
       args:
-        NODE_VERSION: ${NODE_VERSION:-16.10.0}
+        NODE_VERSION: ${NODE_VERSION:-16.13.0}
         ADDITIONAL_GROUPS: "${ARCH_USER_GROUPS:-}"
         FROM_IMAGE: ${ARCH_BASE_IMAGE:-}
-        FROM_IMAGE_DEFAULT: nvidia/cudagl:${CUDA_VERSION:-11.4.2}-devel-${LINUX_VERSION:-ubuntu20.04}
+        FROM_IMAGE_DEFAULT: gpuci/cuda:${CUDA_VERSION:-11.5.0}-devel-${LINUX_VERSION:-ubuntu20.04}
         SCCACHE_REGION: "${SCCACHE_REGION:-}"
         SCCACHE_BUCKET: "${SCCACHE_BUCKET:-}"
         SCCACHE_IDLE_TIMEOUT: "${SCCACHE_IDLE_TIMEOUT:-}"
@@ -66,28 +66,28 @@ services:
 
   packages:
     <<: *base_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-devel-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-packages-${ARCH:-amd64}
+    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-devel-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-packages
     build:
       <<: *base_build_settings
       dockerfile: dockerfiles/devel/package.Dockerfile
       args:
         PARALLEL_LEVEL: "${PARALLEL_LEVEL:-4}"
-        RAPIDS_VERSION: "${RAPIDS_VERSION:-21.12.00}"
+        RAPIDS_VERSION: "${RAPIDS_VERSION:-22.02.00}"
         SCCACHE_REGION: "${SCCACHE_REGION:-us-west-2}"
         SCCACHE_BUCKET: "${SCCACHE_BUCKET:-node-rapids-sccache}"
         SCCACHE_IDLE_TIMEOUT: "${SCCACHE_IDLE_TIMEOUT:-32768}"
         AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID:-}"
         AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY:-}"
-        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-devel-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-main-${ARCH:-amd64}
+        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-devel-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-main
 
   notebook:
     <<: *main_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-devel-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-notebook-${ARCH:-amd64}
+    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-devel-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-notebook
     build:
       <<: *base_build_settings
       dockerfile: dockerfiles/devel/notebook.Dockerfile
       args:
-        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-devel-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-main-${ARCH:-amd64}
+        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-devel-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-main
     environment:
       <<: *main_environment_settings
       QT_AUTO_SCREEN_SCALE_FACTOR: 0

--- a/docker-compose.runtime.yml
+++ b/docker-compose.runtime.yml
@@ -21,7 +21,7 @@ x-main-service-settings: &main_service_settings
   build: &main_build_settings
     <<: *base_build_settings
     args: &main_build_args
-      DEVEL_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-devel-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-packages-${ARCH:-amd64}
+      DEVEL_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-devel-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-packages
   environment: &main_environment_variables
     <<: *base_environment_settings
     # Use the host's X11 display
@@ -31,9 +31,9 @@ x-main-service-settings: &main_service_settings
 
 services:
 
-  cuda-base:
+  base:
     <<: *base_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cuda${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-base-${ARCH:-amd64}
+    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-base
     build:
       <<: *base_build_settings
       dockerfile: dockerfiles/runtime/base.Dockerfile
@@ -41,111 +41,98 @@ services:
         UID: ${UID:-1000}
         ADDITIONAL_GROUPS: ${ARCH_USER_GROUPS:-}
         FROM_IMAGE: ${ARCH_BASE_IMAGE:-}
-        FROM_IMAGE_DEFAULT: nvidia/cuda:${CUDA_VERSION:-11.4.2}-runtime-${LINUX_VERSION:-ubuntu20.04}
-        DEVEL_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-devel-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-main-${ARCH:-amd64}
-
-  cudagl-base:
-    <<: *base_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-base-${ARCH:-amd64}
-    build:
-      <<: *base_build_settings
-      dockerfile: dockerfiles/runtime/base.Dockerfile
-      args:
-        UID: ${UID:-1000}
-        ADDITIONAL_GROUPS: ${ARCH_USER_GROUPS:-}
-        FROM_IMAGE: ${ARCH_BASE_IMAGE:-}
-        FROM_IMAGE_DEFAULT: nvidia/cudagl:${CUDA_VERSION:-11.4.2}-runtime-${LINUX_VERSION:-ubuntu20.04}
-        DEVEL_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-devel-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-main-${ARCH:-amd64}
+        FROM_IMAGE_DEFAULT: gpuci/cuda:${CUDA_VERSION:-11.5.0}-runtime-${LINUX_VERSION:-ubuntu20.04}
+        DEVEL_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-devel-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-main
 
   main:
     <<: *main_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-main-${ARCH:-amd64}
+    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-main
     build:
       <<: *main_build_settings
       dockerfile: dockerfiles/runtime/main.Dockerfile
       args:
         <<: *main_build_args
-        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-base-${ARCH:-amd64}
+        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-base
 
   demo:
     <<: *main_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-demo-${ARCH:-amd64}
+    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-demo
     build:
       <<: *main_build_settings
       dockerfile: dockerfiles/runtime/demo.Dockerfile
       args:
         <<: *main_build_args
-        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-base-${ARCH:-amd64}
+        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-base
 
   glfw:
     <<: *main_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-glfw-${ARCH:-amd64}
+    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-glfw
     build:
       <<: *main_build_settings
       dockerfile: dockerfiles/runtime/glfw.Dockerfile
       args:
         <<: *main_build_args
-        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-base-${ARCH:-amd64}
+        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-base
 
   cudf:
     <<: *main_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cuda${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-cudf-${ARCH:-amd64}
+    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-cudf
     build:
       <<: *main_build_settings
       dockerfile: dockerfiles/runtime/cudf.Dockerfile
       args:
         <<: *main_build_args
-        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cuda${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-base-${ARCH:-amd64}
+        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-base
 
   sql:
     <<: *main_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cuda${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-sql-${ARCH:-amd64}
+    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-sql
     build:
       <<: *main_build_settings
       dockerfile: dockerfiles/runtime/sql.Dockerfile
       args:
         <<: *main_build_args
-        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cuda${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-base-${ARCH:-amd64}
+        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-base
 
   cuml:
     <<: *main_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cuda${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-cuml-${ARCH:-amd64}
+    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-cuml
     build:
       <<: *main_build_settings
       dockerfile: dockerfiles/runtime/cuml.Dockerfile
       args:
         <<: *main_build_args
-        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cuda${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-base-${ARCH:-amd64}
+        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-base
 
   cugraph:
     <<: *main_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cuda${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-cugraph-${ARCH:-amd64}
+    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-cugraph
     build:
       <<: *main_build_settings
       dockerfile: dockerfiles/runtime/cugraph.Dockerfile
       args:
         <<: *main_build_args
-        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cuda${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-base-${ARCH:-amd64}
+        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-base
 
   cuspatial:
     <<: *main_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cuda${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-cuspatial-${ARCH:-amd64}
+    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-cuspatial
     build:
       <<: *main_build_settings
       dockerfile: dockerfiles/runtime/cuspatial.Dockerfile
       args:
         <<: *main_build_args
-        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cuda${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-base-${ARCH:-amd64}
+        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-base
 
   notebook:
     <<: *main_service_settings
-    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-notebook-${ARCH:-amd64}
+    image: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-notebook
     build:
       <<: *main_build_settings
       dockerfile: dockerfiles/runtime/notebook.Dockerfile
       args:
         <<: *main_build_args
-        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-21.12.00}-runtime-node${NODE_VERSION:-16.10.0}-cudagl${CUDA_VERSION:-11.4.2}-${LINUX_VERSION:-ubuntu20.04}-demo-${ARCH:-amd64}
+        FROM_IMAGE: ${REPOSITORY:-ghcr.io/rapidsai/node}:${RAPIDS_VERSION:-22.02.00}-runtime-node${NODE_VERSION:-16.13.0}-cuda${CUDA_VERSION:-11.5.0}-${LINUX_VERSION:-ubuntu20.04}-demo
     volumes:
       - "/etc/fonts:/etc/fonts:ro"
       - "/tmp/.X11-unix:/tmp/.X11-unix:rw"

--- a/dockerfiles/devel/main.Dockerfile
+++ b/dockerfiles/devel/main.Dockerfile
@@ -261,7 +261,7 @@ deb-src  http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -c
     # UCX build dependencies
     automake autoconf libtool \
     # UCX runtime dependencies
-    libibverbs-dev librdmacm-dev libnuma-dev libhwloc-dev \
+    libibverbs-dev librdmacm-dev libnuma-dev \
  \
  # Set alternatives for clangd
  && (update-alternatives --remove-all clangd >/dev/null 2>&1 || true) \

--- a/dockerfiles/devel/main.Dockerfile
+++ b/dockerfiles/devel/main.Dockerfile
@@ -363,6 +363,7 @@ export PROMPT_COMMAND=\"history -a; \$PROMPT_COMMAND\";\n\
     /etc/apt/sources.list.d/llvm-${CLANG_FORMAT_VERSION}.list
 
 ENV NODE_PATH=/usr/local/lib/node_modules
+ENV NODE_OPTIONS="--experimental-vm-modules --trace-uncaught"
 
 COPY --from=wrtc --chown=root:root /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=wrtc --chown=rapids:rapids /opt/rapids/wrtc-0.4.7-dev.tgz /opt/rapids/wrtc-0.4.7-dev.tgz

--- a/dockerfiles/runtime/base.Dockerfile
+++ b/dockerfiles/runtime/base.Dockerfile
@@ -8,13 +8,20 @@ FROM ${FROM_IMAGE:-$FROM_IMAGE_DEFAULT}
 
 SHELL ["/bin/bash", "-c"]
 
+ENV NVIDIA_DRIVER_CAPABILITIES all
+
 ENV CUDA_HOME="/usr/local/cuda"
 ENV LD_LIBRARY_PATH="\
+/usr/lib/aarch64-linux-gnu:\
+/usr/lib/x86_64-linux-gnu:\
+/usr/lib/i386-linux-gnu:\
 ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}\
 ${CUDA_HOME}/lib:\
 ${CUDA_HOME}/lib64:\
 /usr/local/lib:\
 /usr/lib"
+
+ADD --chown=root:root https://gitlab.com/nvidia/container-images/opengl/-/raw/5191cf205d3e4bb1150091f9464499b076104354/glvnd/runtime/10_nvidia.json /usr/share/glvnd/egl_vendor.d/10_nvidia.json
 
 # Install gcc-9 toolchain
 RUN export DEBIAN_FRONTEND=noninteractive \
@@ -25,6 +32,13 @@ RUN export DEBIAN_FRONTEND=noninteractive \
  && apt update \
  && apt install --no-install-recommends -y \
     libstdc++6 \
+    # From opengl/glvnd:runtime
+    libxau6 libxdmcp6 libxcb1 libxext6 libx11-6 \
+    libglvnd0 libgl1 libglx0 libegl1 libgles2 \
+ \
+ && chmod 0644 /usr/share/glvnd/egl_vendor.d/10_nvidia.json \
+ && echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
+ && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf \
  # Clean up
  && add-apt-repository --remove -y ppa:ubuntu-toolchain-r/test \
  && apt remove -y software-properties-common \

--- a/dockerfiles/runtime/base.Dockerfile
+++ b/dockerfiles/runtime/base.Dockerfile
@@ -74,6 +74,8 @@ RUN useradd --uid $UID --user-group ${ADDITIONAL_GROUPS} --shell /bin/bash --cre
  # smoke tests
  && node --version && npm --version && yarn --version
 
+ENV NODE_OPTIONS="--experimental-vm-modules --trace-uncaught"
+
 WORKDIR /home/node
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/dockerfiles/runtime/base.Dockerfile
+++ b/dockerfiles/runtime/base.Dockerfile
@@ -34,7 +34,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     libstdc++6 \
     # From opengl/glvnd:runtime
     libxau6 libxdmcp6 libxcb1 libxext6 libx11-6 \
-    libglvnd0 libgl1 libglx0 libegl1 libgles2 \
+    libglvnd0 libopengl0 libgl1 libglx0 libegl1 libgles2 \
  \
  && chmod 0644 /usr/share/glvnd/egl_vendor.d/10_nvidia.json \
  && echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \

--- a/dockerfiles/runtime/cudf.Dockerfile
+++ b/dockerfiles/runtime/cudf.Dockerfile
@@ -17,8 +17,6 @@ FROM ${FROM_IMAGE}
 
 SHELL ["/bin/bash", "-c"]
 
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
-
 COPY --from=devel --chown=node:node /home/node/node_modules/ /home/node/node_modules/
 
 WORKDIR /home/node

--- a/dockerfiles/runtime/cugraph.Dockerfile
+++ b/dockerfiles/runtime/cugraph.Dockerfile
@@ -18,8 +18,6 @@ FROM ${FROM_IMAGE}
 
 SHELL ["/bin/bash", "-c"]
 
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
-
 COPY --from=devel --chown=node:node /home/node/node_modules/ /home/node/node_modules/
 
 WORKDIR /home/node

--- a/dockerfiles/runtime/cuml.Dockerfile
+++ b/dockerfiles/runtime/cuml.Dockerfile
@@ -18,8 +18,6 @@ FROM ${FROM_IMAGE}
 
 SHELL ["/bin/bash", "-c"]
 
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
-
 COPY --from=devel --chown=node:node /home/node/node_modules/ /home/node/node_modules/
 
 WORKDIR /home/node

--- a/dockerfiles/runtime/cuspatial.Dockerfile
+++ b/dockerfiles/runtime/cuspatial.Dockerfile
@@ -18,8 +18,6 @@ FROM ${FROM_IMAGE}
 
 SHELL ["/bin/bash", "-c"]
 
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
-
 USER root
 
 # Install dependencies

--- a/dockerfiles/runtime/demo.Dockerfile
+++ b/dockerfiles/runtime/demo.Dockerfile
@@ -27,8 +27,6 @@ FROM ${FROM_IMAGE}
 
 SHELL ["/bin/bash", "-c"]
 
-ENV NVIDIA_DRIVER_CAPABILITIES all
-
 USER root
 
 # Install UCX
@@ -67,17 +65,23 @@ RUN cd /usr/local/lib \
     # cuSpatial dependencies
     libgdal-dev \
     # X11 dependencies
-    libxrandr-dev libxinerama-dev libxcursor-dev \
+    libxrandr2 libxinerama1 libxcursor1 \
     # Wayland dependencies
-    libwayland-dev wayland-protocols libxkbcommon-dev \
+    libwayland-bin \
+    wayland-protocols \
+    libwayland-server0 \
+    libwayland-egl1 libwayland-egl++0 \
+    libwayland-cursor0 libwayland-cursor++0 \
+    libwayland-client0 libwayland-client++0 libwayland-client-extra++0 \
+    libxkbcommon0 libxkbcommon-x11-0 \
     # GLEW dependencies
-    libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev \
+    libglvnd0 libgl1 libglx0 libegl1 libgles2 libglu1-mesa \
     # UCX runtime dependencies
-    libibverbs-dev librdmacm-dev libnuma-dev libhwloc-dev \
+    libibverbs1 librdmacm1 libnuma1 libhwloc15 \
     # node-canvas dependencies
-    libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
+    libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libjpeg8 libgif7 librsvg2-2 \
     # SQL dependencies
-    openjdk-8-jre libboost-regex-dev libboost-system-dev libboost-filesystem-dev \
+    openjdk-8-jre-headless libboost-regex-dev libboost-system-dev libboost-filesystem-dev \
  # Clean up
  && apt autoremove -y && apt clean \
  && rm -rf \

--- a/dockerfiles/runtime/demo.Dockerfile
+++ b/dockerfiles/runtime/demo.Dockerfile
@@ -73,7 +73,7 @@ RUN cd /usr/local/lib \
     # GLEW dependencies
     libglvnd0 libgl1 libglx0 libegl1 libgles2 libglu1-mesa \
     # UCX runtime dependencies
-    libibverbs1 librdmacm1 libnuma1 libhwloc15 \
+    libibverbs1 librdmacm1 libnuma1 \
     # node-canvas dependencies
     libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libjpeg8 libgif7 librsvg2-2 \
     # SQL dependencies

--- a/dockerfiles/runtime/demo.Dockerfile
+++ b/dockerfiles/runtime/demo.Dockerfile
@@ -67,12 +67,8 @@ RUN cd /usr/local/lib \
     # X11 dependencies
     libxrandr2 libxinerama1 libxcursor1 \
     # Wayland dependencies
-    libwayland-bin \
     wayland-protocols \
-    libwayland-server0 \
-    libwayland-egl1 libwayland-egl++0 \
-    libwayland-cursor0 libwayland-cursor++0 \
-    libwayland-client0 libwayland-client++0 libwayland-client-extra++0 \
+    libwayland-{bin,egl1,cursor0,client0,server0} \
     libxkbcommon0 libxkbcommon-x11-0 \
     # GLEW dependencies
     libglvnd0 libgl1 libglx0 libegl1 libgles2 libglu1-mesa \

--- a/dockerfiles/runtime/glfw.Dockerfile
+++ b/dockerfiles/runtime/glfw.Dockerfile
@@ -17,21 +17,25 @@ FROM ${FROM_IMAGE}
 
 SHELL ["/bin/bash", "-c"]
 
-ENV NVIDIA_DRIVER_CAPABILITIES all
-
 USER root
 
 RUN export DEBIAN_FRONTEND=noninteractive \
  && apt update \
  && apt install -y --no-install-recommends \
     # X11 dependencies
-    libxrandr-dev libxinerama-dev libxcursor-dev \
+    libxrandr2 libxinerama1 libxcursor1 \
     # Wayland dependencies
-    libwayland-dev wayland-protocols libxkbcommon-dev \
+    libwayland-bin \
+    wayland-protocols \
+    libwayland-server0 \
+    libwayland-egl1 libwayland-egl++0 \
+    libwayland-cursor0 libwayland-cursor++0 \
+    libwayland-client0 libwayland-client++0 libwayland-client-extra++0 \
+    libxkbcommon0 libxkbcommon-x11-0 \
     # GLEW dependencies
-    libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev \
+    libglvnd0 libgl1 libglx0 libegl1 libgles2 libglu1-mesa \
     # node-canvas dependencies
-    libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
+    libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libjpeg8 libgif7 librsvg2-2 \
  # Clean up
  && apt autoremove -y && apt clean \
  && rm -rf \

--- a/dockerfiles/runtime/glfw.Dockerfile
+++ b/dockerfiles/runtime/glfw.Dockerfile
@@ -25,12 +25,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     # X11 dependencies
     libxrandr2 libxinerama1 libxcursor1 \
     # Wayland dependencies
-    libwayland-bin \
     wayland-protocols \
-    libwayland-server0 \
-    libwayland-egl1 libwayland-egl++0 \
-    libwayland-cursor0 libwayland-cursor++0 \
-    libwayland-client0 libwayland-client++0 libwayland-client-extra++0 \
+    libwayland-{bin,egl1,cursor0,client0,server0} \
     libxkbcommon0 libxkbcommon-x11-0 \
     # GLEW dependencies
     libglvnd0 libgl1 libglx0 libegl1 libgles2 libglu1-mesa \

--- a/dockerfiles/runtime/main.Dockerfile
+++ b/dockerfiles/runtime/main.Dockerfile
@@ -66,12 +66,8 @@ RUN cd /usr/local/lib \
     # X11 dependencies
     libxrandr2 libxinerama1 libxcursor1 \
     # Wayland dependencies
-    libwayland-bin \
     wayland-protocols \
-    libwayland-server0 \
-    libwayland-egl1 libwayland-egl++0 \
-    libwayland-cursor0 libwayland-cursor++0 \
-    libwayland-client0 libwayland-client++0 libwayland-client-extra++0 \
+    libwayland-{bin,egl1,cursor0,client0,server0} \
     libxkbcommon0 libxkbcommon-x11-0 \
     # GLEW dependencies
     libglvnd0 libgl1 libglx0 libegl1 libgles2 libglu1-mesa \

--- a/dockerfiles/runtime/main.Dockerfile
+++ b/dockerfiles/runtime/main.Dockerfile
@@ -26,8 +26,6 @@ FROM ${FROM_IMAGE}
 
 SHELL ["/bin/bash", "-c"]
 
-ENV NVIDIA_DRIVER_CAPABILITIES all
-
 USER root
 
 # Install UCX
@@ -66,17 +64,23 @@ RUN cd /usr/local/lib \
     # cuSpatial dependencies
     libgdal-dev \
     # X11 dependencies
-    libxrandr-dev libxinerama-dev libxcursor-dev \
+    libxrandr2 libxinerama1 libxcursor1 \
     # Wayland dependencies
-    libwayland-dev wayland-protocols libxkbcommon-dev \
+    libwayland-bin \
+    wayland-protocols \
+    libwayland-server0 \
+    libwayland-egl1 libwayland-egl++0 \
+    libwayland-cursor0 libwayland-cursor++0 \
+    libwayland-client0 libwayland-client++0 libwayland-client-extra++0 \
+    libxkbcommon0 libxkbcommon-x11-0 \
     # GLEW dependencies
-    libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev \
+    libglvnd0 libgl1 libglx0 libegl1 libgles2 libglu1-mesa \
     # UCX runtime dependencies
-    libibverbs-dev librdmacm-dev libnuma-dev libhwloc-dev \
+    libibverbs1 librdmacm1 libnuma1 libhwloc15 \
     # node-canvas dependencies
-    libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
+    libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libjpeg8 libgif7 librsvg2-2 \
     # SQL dependencies
-    openjdk-8-jre libboost-regex-dev libboost-system-dev libboost-filesystem-dev \
+    openjdk-8-jre-headless libboost-regex-dev libboost-system-dev libboost-filesystem-dev \
  # Clean up
  && apt autoremove -y && apt clean \
  && rm -rf \

--- a/dockerfiles/runtime/main.Dockerfile
+++ b/dockerfiles/runtime/main.Dockerfile
@@ -72,7 +72,7 @@ RUN cd /usr/local/lib \
     # GLEW dependencies
     libglvnd0 libgl1 libglx0 libegl1 libgles2 libglu1-mesa \
     # UCX runtime dependencies
-    libibverbs1 librdmacm1 libnuma1 libhwloc15 \
+    libibverbs1 librdmacm1 libnuma1 \
     # node-canvas dependencies
     libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libjpeg8 libgif7 librsvg2-2 \
     # SQL dependencies

--- a/dockerfiles/runtime/notebook.Dockerfile
+++ b/dockerfiles/runtime/notebook.Dockerfile
@@ -6,8 +6,6 @@ SHELL ["/bin/bash", "-c"]
 
 ARG TARGETARCH
 
-ENV NVIDIA_DRIVER_CAPABILITIES all
-
 ADD --chown=node:node \
     https://raw.githubusercontent.com/n-riesco/ijavascript/8637a3e18b89270121f49733d03af0e3e6e0a17a/images/nodejs/js-green-32x32.png \
     /home/node/.local/share/jupyter/kernels/javascript/logo-32x32.png

--- a/dockerfiles/runtime/sql.Dockerfile
+++ b/dockerfiles/runtime/sql.Dockerfile
@@ -18,8 +18,6 @@ FROM ${FROM_IMAGE}
 
 SHELL ["/bin/bash", "-c"]
 
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
-
 USER root
 
 # Install UCX
@@ -56,9 +54,9 @@ RUN cd /usr/local/lib \
  && apt update \
  && apt install -y --no-install-recommends \
     # UCX runtime dependencies
-    libibverbs-dev librdmacm-dev libnuma-dev libhwloc-dev \
+    libibverbs1 librdmacm1 libnuma1 libhwloc15 \
     # SQL dependencies
-    openjdk-8-jre libboost-regex-dev libboost-system-dev libboost-filesystem-dev \
+    openjdk-8-jre-headless libboost-regex-dev libboost-system-dev libboost-filesystem-dev \
  # Clean up
  && apt autoremove -y && apt clean \
  && rm -rf \

--- a/dockerfiles/runtime/sql.Dockerfile
+++ b/dockerfiles/runtime/sql.Dockerfile
@@ -54,7 +54,7 @@ RUN cd /usr/local/lib \
  && apt update \
  && apt install -y --no-install-recommends \
     # UCX runtime dependencies
-    libibverbs1 librdmacm1 libnuma1 libhwloc15 \
+    libibverbs1 librdmacm1 libnuma1 \
     # SQL dependencies
     openjdk-8-jre-headless libboost-regex-dev libboost-system-dev libboost-filesystem-dev \
  # Clean up

--- a/modules/core/cmake/Modules/ConfigureCUDF.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUDF.cmake
@@ -42,7 +42,7 @@ function(find_and_configure_cudf VERSION)
             # GIT_REPOSITORY      https://github.com/rapidsai/cudf.git
             # GIT_TAG             branch-${MAJOR_AND_MINOR}
             GIT_REPOSITORY      https://github.com/trxcllnt/cudf.git
-            GIT_TAG             fix/arrow-parquet-targets
+            GIT_TAG             fix/arrow-parquet-targets-${MAJOR_AND_MINOR}
             GIT_SHALLOW         TRUE
             ${UPDATE_DISCONNECTED}
             SOURCE_SUBDIR       cpp

--- a/modules/core/cmake/Modules/ConfigureCUML.cmake
+++ b/modules/core/cmake/Modules/ConfigureCUML.cmake
@@ -24,11 +24,9 @@ function(find_and_configure_cuml VERSION)
 
     _set_package_dir_if_exists(cuml cuml)
     _set_package_dir_if_exists(raft raft)
-    _set_package_dir_if_exists(fmt fmtlib)
     _set_package_dir_if_exists(faiss faiss)
     _set_package_dir_if_exists(Thrust thrust)
     _set_package_dir_if_exists(Treelite treelite)
-    _set_package_dir_if_exists(RapidJSON rapidjson)
 
     if(NOT TARGET cuml::cuml)
         _get_major_minor_version(${VERSION} MAJOR_AND_MINOR)

--- a/modules/cudf/CMakeLists.txt
+++ b/modules/cudf/CMakeLists.txt
@@ -25,8 +25,8 @@ unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(DISABLE_DEPRECATION_WARNINGS "Disable warnings generated from deprecated declarations." ON)
 
-set(RMM_VERSION "21.12.00")
-set(CUDF_VERSION "21.12.00")
+set(RMM_VERSION "22.02.00")
+set(CUDF_VERSION "22.02.00")
 
 ###################################################################################################
 # - cmake modules ---------------------------------------------------------------------------------

--- a/modules/cudf/notebooks/Basic Demo.ipynb
+++ b/modules/cudf/notebooks/Basic Demo.ipynb
@@ -575,7 +575,7 @@
     },
     "language_info": {
       "name": "javascript",
-      "version": "16.10.0",
+      "version": "16.13.0",
       "mimetype": "application/javascript",
       "file_extension": ".js"
     },

--- a/modules/cudf/notebooks/Geospatial Demo.ipynb
+++ b/modules/cudf/notebooks/Geospatial Demo.ipynb
@@ -230,7 +230,7 @@
     },
     "language_info": {
       "name": "javascript",
-      "version": "16.10.0",
+      "version": "16.13.0",
       "mimetype": "application/javascript",
       "file_extension": ".js"
     },

--- a/modules/cudf/notebooks/Wikipedia.ipynb
+++ b/modules/cudf/notebooks/Wikipedia.ipynb
@@ -463,7 +463,7 @@
     },
     "language_info": {
       "name": "javascript",
-      "version": "16.10.0",
+      "version": "16.13.0",
       "mimetype": "application/javascript",
       "file_extension": ".js"
     },

--- a/modules/cudf/src/node_cudf/utilities/scalar_to_value.hpp
+++ b/modules/cudf/src/node_cudf/utilities/scalar_to_value.hpp
@@ -16,6 +16,7 @@
 
 #include <node_cudf/column.hpp>
 
+#include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/traits.hpp>
@@ -30,21 +31,71 @@ namespace detail {
 
 struct get_scalar_value {
   Napi::Env env;
+
   template <typename T>
-  inline std::enable_if_t<cudf::is_index_type<T>(), Napi::Value> operator()(
+  inline std::enable_if_t<std::is_same_v<T, int8_t>, Napi::Value> operator()(
     std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
-    if (!scalar->is_valid(stream)) { return env.Null(); }
-    switch (scalar->type().id()) {
-      case cudf::type_id::INT64:
-        return Napi::BigInt::New(
-          env, static_cast<cudf::numeric_scalar<int64_t>*>(scalar.get())->value(stream));
-      case cudf::type_id::UINT64:
-        return Napi::BigInt::New(
-          env, static_cast<cudf::numeric_scalar<uint64_t>*>(scalar.get())->value(stream));
-      default:
-        return Napi::Number::New(
-          env, static_cast<cudf::numeric_scalar<T>*>(scalar.get())->value(stream));
-    }
+    return scalar->is_valid(stream)
+             ? Napi::Number::New(env,
+                                 static_cast<cudf::numeric_scalar<T>*>(scalar.get())->value(stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, int16_t>, Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? Napi::Number::New(env,
+                                 static_cast<cudf::numeric_scalar<T>*>(scalar.get())->value(stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, int32_t>, Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? Napi::Number::New(env,
+                                 static_cast<cudf::numeric_scalar<T>*>(scalar.get())->value(stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, int64_t>, Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? Napi::BigInt::New(env,
+                                 static_cast<cudf::numeric_scalar<T>*>(scalar.get())->value(stream))
+             : env.Null();
+  }
+
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, uint8_t>, Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? Napi::Number::New(env,
+                                 static_cast<cudf::numeric_scalar<T>*>(scalar.get())->value(stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, uint16_t>, Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? Napi::Number::New(env,
+                                 static_cast<cudf::numeric_scalar<T>*>(scalar.get())->value(stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, uint32_t>, Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? Napi::Number::New(env,
+                                 static_cast<cudf::numeric_scalar<T>*>(scalar.get())->value(stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, uint64_t>, Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? Napi::BigInt::New(env,
+                                 static_cast<cudf::numeric_scalar<T>*>(scalar.get())->value(stream))
+             : env.Null();
   }
   template <typename T>
   inline std::enable_if_t<cudf::is_floating_point<T>(), Napi::Value> operator()(
@@ -55,7 +106,7 @@ struct get_scalar_value {
              : env.Null();
   }
   template <typename T>
-  inline std::enable_if_t<std::is_same<T, bool>::value, Napi::Value> operator()(
+  inline std::enable_if_t<std::is_same_v<T, bool>, Napi::Value> operator()(
     std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
     return scalar->is_valid(stream)
              ? Napi::Boolean::New(
@@ -63,7 +114,7 @@ struct get_scalar_value {
              : env.Null();
   }
   template <typename T>
-  inline std::enable_if_t<std::is_same<T, cudf::string_view>::value, Napi::Value> operator()(
+  inline std::enable_if_t<std::is_same_v<T, cudf::string_view>, Napi::Value> operator()(
     std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
     return scalar->is_valid(stream)
              ? Napi::Value::From(env,
@@ -87,7 +138,7 @@ struct get_scalar_value {
              : env.Null();
   }
   template <typename T>
-  inline std::enable_if_t<cudf::is_fixed_point<T>(), Napi::Value> operator()(
+  inline std::enable_if_t<std::is_same_v<T, numeric::decimal32>, Napi::Value> operator()(
     std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
     return scalar->is_valid(stream)
              ? Napi::Value::From(
@@ -95,7 +146,15 @@ struct get_scalar_value {
              : env.Null();
   }
   template <typename T>
-  inline std::enable_if_t<std::is_same<T, cudf::list_view>::value, Napi::Value> operator()(
+  inline std::enable_if_t<std::is_same_v<T, numeric::decimal64>, Napi::Value> operator()(
+    std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
+    return scalar->is_valid(stream)
+             ? Napi::Value::From(
+                 env, static_cast<cudf::fixed_point_scalar<T>*>(scalar.get())->value(stream))
+             : env.Null();
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, cudf::list_view>, Napi::Value> operator()(
     std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
     return scalar->is_valid(stream)
              ? Column::New(env,
@@ -107,14 +166,14 @@ struct get_scalar_value {
              : env.Null();
   }
   template <typename T>
-  inline std::enable_if_t<!(cudf::is_index_type<T>() ||                   //
-                            cudf::is_floating_point<T>() ||               //
-                            std::is_same<T, bool>::value ||               //
-                            std::is_same<T, cudf::string_view>::value ||  //
-                            cudf::is_duration<T>() ||                     //
-                            cudf::is_timestamp<T>() ||                    //
-                            cudf::is_fixed_point<T>() ||                  //
-                            std::is_same<T, cudf::list_view>::value),
+  inline std::enable_if_t<!(cudf::is_chrono<T>() ||                   //
+                            cudf::is_index_type<T>() ||               //
+                            cudf::is_floating_point<T>() ||           //
+                            std::is_same_v<T, bool> ||                //
+                            std::is_same_v<T, cudf::string_view> ||   //
+                            std::is_same_v<T, numeric::decimal32> ||  //
+                            std::is_same_v<T, numeric::decimal64> ||  //
+                            std::is_same_v<T, cudf::list_view>),
                           Napi::Value>
   operator()(std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
     NAPI_THROW(Napi::Error::New(env, "Unsupported dtype"));

--- a/modules/cudf/src/node_cudf/utilities/value_to_scalar.hpp
+++ b/modules/cudf/src/node_cudf/utilities/value_to_scalar.hpp
@@ -16,6 +16,7 @@
 
 #include <node_cudf/column.hpp>
 
+#include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/traits.hpp>
 
@@ -24,46 +25,136 @@
 namespace nv {
 namespace detail {
 
+namespace scalar {
+inline int64_t get_int64(Napi::Value const& val) {
+  bool lossless = true;
+  return !val.IsBigInt() ? val.ToNumber().Int64Value()
+                         : val.As<Napi::BigInt>().Int64Value(&lossless);
+}
+
+inline uint64_t get_uint64(Napi::Value const& val) {
+  bool lossless = true;
+  return !val.IsBigInt() ? static_cast<uint64_t>(val.ToNumber().Int64Value())
+                         : val.As<Napi::BigInt>().Uint64Value(&lossless);
+}
+}  // namespace scalar
+
 struct set_scalar_value {
   Napi::Value val;
 
   template <typename T>
-  inline std::enable_if_t<cudf::is_numeric<T>(), void> operator()(
+  inline std::enable_if_t<std::is_same_v<T, int8_t>, void> operator()(
     std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
-    static_cast<cudf::numeric_scalar<T>*>(scalar.get())->set_value(NapiToCPP(val), stream);
+    static_cast<cudf::numeric_scalar<T>*>(scalar.get())
+      ->set_value(static_cast<T>(scalar::get_int64(val)), stream);
   }
   template <typename T>
-  inline std::enable_if_t<std::is_same<T, cudf::string_view>::value, void> operator()(
+  inline std::enable_if_t<std::is_same_v<T, int16_t>, void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::numeric_scalar<T>*>(scalar.get())
+      ->set_value(static_cast<T>(scalar::get_int64(val)), stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, int32_t>, void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::numeric_scalar<T>*>(scalar.get())
+      ->set_value(static_cast<T>(scalar::get_int64(val)), stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, int64_t>, void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::numeric_scalar<T>*>(scalar.get())
+      ->set_value(static_cast<T>(scalar::get_int64(val)), stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, uint8_t>, void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::numeric_scalar<T>*>(scalar.get())
+      ->set_value(static_cast<T>(scalar::get_uint64(val)), stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, uint16_t>, void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::numeric_scalar<T>*>(scalar.get())
+      ->set_value(static_cast<T>(scalar::get_uint64(val)), stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, uint32_t>, void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::numeric_scalar<T>*>(scalar.get())
+      ->set_value(static_cast<T>(scalar::get_uint64(val)), stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, uint64_t>, void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::numeric_scalar<T>*>(scalar.get())
+      ->set_value(static_cast<T>(scalar::get_uint64(val)), stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<cudf::is_floating_point<T>(), void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::numeric_scalar<T>*>(scalar.get())->set_value(val.ToNumber(), stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, bool>, void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::numeric_scalar<T>*>(scalar.get())->set_value(val.ToBoolean(), stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, cudf::string_view>, void> operator()(
     std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
     scalar.reset(new cudf::string_scalar(val.ToString(), true, stream));
   }
   template <typename T>
-  inline std::enable_if_t<cudf::is_duration<T>(), void> operator()(
-    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
-    static_cast<cudf::duration_scalar<T>*>(scalar.get())->set_value(NapiToCPP(val), stream);
+  inline std::enable_if_t<cudf::is_duration<T>() and std::is_same_v<typename T::rep, int32_t>, void>
+  operator()(std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::duration_scalar<T>*>(scalar.get())
+      ->set_value(T{val.ToNumber().Int32Value()}, stream);
   }
   template <typename T>
-  inline std::enable_if_t<cudf::is_timestamp<T>(), void> operator()(
-    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
-    static_cast<cudf::timestamp_scalar<T>*>(scalar.get())->set_value(NapiToCPP(val), stream);
+  inline std::enable_if_t<cudf::is_duration<T>() and std::is_same_v<typename T::rep, int64_t>, void>
+  operator()(std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::duration_scalar<T>*>(scalar.get())
+      ->set_value(T{scalar::get_int64(val)}, stream);
   }
   template <typename T>
-  inline std::enable_if_t<cudf::is_fixed_point<T>(), void> operator()(
+  inline std::enable_if_t<cudf::is_timestamp<T>() and std::is_same_v<typename T::rep, int32_t>,
+                          void>
+  operator()(std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::timestamp_scalar<T>*>(scalar.get())
+      ->set_value(T{typename T::duration{val.ToNumber().Int32Value()}}, stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<cudf::is_timestamp<T>() and std::is_same_v<typename T::rep, int64_t>,
+                          void>
+  operator()(std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    static_cast<cudf::timestamp_scalar<T>*>(scalar.get())
+      ->set_value(T{typename T::duration{scalar::get_int64(val)}}, stream);
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, numeric::decimal32>, void> operator()(
     std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
     scalar.reset(new cudf::fixed_point_scalar<T>(val.ToNumber(), true, stream));
   }
   template <typename T>
-  inline std::enable_if_t<std::is_same<T, cudf::list_view>::value, void> operator()(
+  inline std::enable_if_t<std::is_same_v<T, numeric::decimal64>, void> operator()(
+    std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
+    scalar.reset(new cudf::fixed_point_scalar<T>(val.ToNumber(), true, stream));
+  }
+  template <typename T>
+  inline std::enable_if_t<std::is_same_v<T, cudf::list_view>, void> operator()(
     std::unique_ptr<cudf::scalar>& scalar, cudaStream_t stream = 0) {
     scalar.reset(new cudf::list_scalar(*Column::Unwrap(val.ToObject()), true, stream));
   }
   template <typename T>
-  inline std::enable_if_t<!(cudf::is_numeric<T>() ||                      //
-                            std::is_same<T, cudf::string_view>::value ||  //
-                            cudf::is_duration<T>() ||                     //
-                            cudf::is_timestamp<T>() ||                    //
-                            cudf::is_fixed_point<T>() ||                  //
-                            std::is_same<T, cudf::list_view>::value),
+  inline std::enable_if_t<!(cudf::is_chrono<T>() ||                   //
+                            cudf::is_index_type<T>() ||               //
+                            cudf::is_floating_point<T>() ||           //
+                            std::is_same_v<T, bool> ||                //
+                            std::is_same_v<T, cudf::string_view> ||   //
+                            std::is_same_v<T, numeric::decimal32> ||  //
+                            std::is_same_v<T, numeric::decimal64> ||  //
+                            std::is_same_v<T, cudf::list_view>),
                           void>
   operator()(std::unique_ptr<cudf::scalar> const& scalar, cudaStream_t stream = 0) {
     NAPI_THROW(Napi::Error::New(val.Env(), "Unsupported dtype"));

--- a/modules/cugraph/CMakeLists.txt
+++ b/modules/cugraph/CMakeLists.txt
@@ -28,10 +28,10 @@ unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(DISABLE_DEPRECATION_WARNINGS "Disable warnings generated from deprecated declarations." ON)
 
-set(RMM_VERSION "21.12.00")
-set(CUDF_VERSION "21.12.00")
-set(CUGRAPH_VERSION "21.12.00")
-set(RAFT_VERSION "21.12.00")
+set(RMM_VERSION "22.02.00")
+set(CUDF_VERSION "22.02.00")
+set(CUGRAPH_VERSION "22.02.00")
+set(RAFT_VERSION "22.02.00")
 
 ###################################################################################################
 # - cmake modules ---------------------------------------------------------------------------------

--- a/modules/cuml/CMakeLists.txt
+++ b/modules/cuml/CMakeLists.txt
@@ -28,10 +28,10 @@ unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(DISABLE_DEPRECATION_WARNINGS "Disable warnings generated from deprecated declarations." ON)
 
-set(RMM_VERSION "21.12.00")
-set(CUDF_VERSION "21.12.00")
-set(CUML_VERSION "21.12.00")
-set(RAFT_VERSION "21.12.00")
+set(RMM_VERSION "22.02.00")
+set(CUDF_VERSION "22.02.00")
+set(CUML_VERSION "22.02.00")
+set(RAFT_VERSION "22.02.00")
 
 ###################################################################################################
 # - cmake modules ---------------------------------------------------------------------------------

--- a/modules/cuspatial/CMakeLists.txt
+++ b/modules/cuspatial/CMakeLists.txt
@@ -24,9 +24,9 @@ unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(DISABLE_DEPRECATION_WARNINGS "Disable warnings generated from deprecated declarations." ON)
 
-set(RMM_VERSION "21.12.00")
-set(CUDF_VERSION "21.12.00")
-set(CUSPATIAL_VERSION "21.12.00")
+set(RMM_VERSION "22.02.00")
+set(CUDF_VERSION "22.02.00")
+set(CUSPATIAL_VERSION "22.02.00")
 
 ###################################################################################################
 # - cmake modules ---------------------------------------------------------------------------------

--- a/modules/demo/client-server/index.js
+++ b/modules/demo/client-server/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2021, NVIDIA CORPORATION.
 //

--- a/modules/demo/client-server/package.json
+++ b/modules/demo/client-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rapidsai/demo-client-server",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/3d-heatmap/index.js
+++ b/modules/demo/deck/3d-heatmap/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/3d-heatmap/package.json
+++ b/modules/demo/deck/3d-heatmap/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-3d-heatmap",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/3d-tiles/index.js
+++ b/modules/demo/deck/3d-tiles/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/3d-tiles/package.json
+++ b/modules/demo/deck/3d-tiles/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-3d-tiles",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/arc/index.js
+++ b/modules/demo/deck/arc/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/arc/package.json
+++ b/modules/demo/deck/arc/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-arc",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/bezier/index.js
+++ b/modules/demo/deck/bezier/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/bezier/package.json
+++ b/modules/demo/deck/bezier/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-bezier",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "main": "index.js",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",

--- a/modules/demo/deck/brushing/index.js
+++ b/modules/demo/deck/brushing/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/brushing/package.json
+++ b/modules/demo/deck/brushing/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-brushing",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/geojson/index.js
+++ b/modules/demo/deck/geojson/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/geojson/package.json
+++ b/modules/demo/deck/geojson/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-geojson",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/heatmap/index.js
+++ b/modules/demo/deck/heatmap/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/heatmap/package.json
+++ b/modules/demo/deck/heatmap/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-heatmap",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/highway/index.js
+++ b/modules/demo/deck/highway/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/highway/package.json
+++ b/modules/demo/deck/highway/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-highway",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/icon/index.js
+++ b/modules/demo/deck/icon/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/icon/package.json
+++ b/modules/demo/deck/icon/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-icon",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/image-tile/index.js
+++ b/modules/demo/deck/image-tile/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/image-tile/package.json
+++ b/modules/demo/deck/image-tile/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-image-tile",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/interleaved-buffer/index.js
+++ b/modules/demo/deck/interleaved-buffer/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/interleaved-buffer/package.json
+++ b/modules/demo/deck/interleaved-buffer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-interleaved-buffer",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/line/index.js
+++ b/modules/demo/deck/line/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/line/package.json
+++ b/modules/demo/deck/line/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-line",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/map-tile/index.js
+++ b/modules/demo/deck/map-tile/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/map-tile/package.json
+++ b/modules/demo/deck/map-tile/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-map-tile",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/mesh/index.js
+++ b/modules/demo/deck/mesh/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/playground/index.js
+++ b/modules/demo/deck/playground/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/playground/package.json
+++ b/modules/demo/deck/playground/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-playground",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/plot/index.js
+++ b/modules/demo/deck/plot/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/plot/package.json
+++ b/modules/demo/deck/plot/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-plot",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/point-cloud/index.js
+++ b/modules/demo/deck/point-cloud/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/point-cloud/package.json
+++ b/modules/demo/deck/point-cloud/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-point-cloud-laz",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/scatterplot/index.js
+++ b/modules/demo/deck/scatterplot/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/scatterplot/package.json
+++ b/modules/demo/deck/scatterplot/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-scatterplot",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/scenegraph-layer/index.js
+++ b/modules/demo/deck/scenegraph-layer/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/scenegraph-layer/package.json
+++ b/modules/demo/deck/scenegraph-layer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-scenegraph-layer-demo",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/screen-grid/index.js
+++ b/modules/demo/deck/screen-grid/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/screen-grid/package.json
+++ b/modules/demo/deck/screen-grid/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-screengrid",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/tagmap/index.js
+++ b/modules/demo/deck/tagmap/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/tagmap/package.json
+++ b/modules/demo/deck/tagmap/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-tagmap",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/text-layer/index.js
+++ b/modules/demo/deck/text-layer/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/text-layer/package.json
+++ b/modules/demo/deck/text-layer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-text-layer",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/trips/index.js
+++ b/modules/demo/deck/trips/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/trips/package.json
+++ b/modules/demo/deck/trips/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-trips",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/deck/worldmap/index.js
+++ b/modules/demo/deck/worldmap/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/deck/worldmap/package.json
+++ b/modules/demo/deck/worldmap/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-deck-worldmap",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/graph/Graph Demo.ipynb
+++ b/modules/demo/graph/Graph Demo.ipynb
@@ -51,7 +51,7 @@
     },
     "language_info": {
       "name": "javascript",
-      "version": "16.10.0",
+      "version": "16.13.0",
       "mimetype": "application/javascript",
       "file_extension": ".js"
     },

--- a/modules/demo/graph/index.js
+++ b/modules/demo/graph/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020-2021, NVIDIA CORPORATION.
 //

--- a/modules/demo/graph/package.json
+++ b/modules/demo/graph/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@rapidsai/demo-graph",
   "main": "index.js",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/ipc/graph/index.js
+++ b/modules/demo/ipc/graph/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020-2021, NVIDIA CORPORATION.
 //

--- a/modules/demo/ipc/graph/package.json
+++ b/modules/demo/ipc/graph/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@rapidsai/demo-ipc-graph",
   "main": "index.js",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/ipc/graph/src/index.js
+++ b/modules/demo/ipc/graph/src/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/ipc/umap/index.js
+++ b/modules/demo/ipc/umap/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020-2021, NVIDIA CORPORATION.
 //

--- a/modules/demo/ipc/umap/package.json
+++ b/modules/demo/ipc/umap/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@rapidsai/demo-ipc-umap",
   "main": "index.js",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/luma/index.js
+++ b/modules/demo/luma/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020, NVIDIA CORPORATION.
 //

--- a/modules/demo/luma/lessons/01/package.json
+++ b/modules/demo/luma/lessons/01/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-01",
   "scripts": {

--- a/modules/demo/luma/lessons/02/package.json
+++ b/modules/demo/luma/lessons/02/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-02",
   "scripts": {

--- a/modules/demo/luma/lessons/03/package.json
+++ b/modules/demo/luma/lessons/03/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-03",
   "scripts": {

--- a/modules/demo/luma/lessons/04/package.json
+++ b/modules/demo/luma/lessons/04/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-04",
   "scripts": {

--- a/modules/demo/luma/lessons/05/package.json
+++ b/modules/demo/luma/lessons/05/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-05",
   "scripts": {

--- a/modules/demo/luma/lessons/06/package.json
+++ b/modules/demo/luma/lessons/06/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-06",
   "scripts": {

--- a/modules/demo/luma/lessons/07/package.json
+++ b/modules/demo/luma/lessons/07/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-07",
   "scripts": {

--- a/modules/demo/luma/lessons/08/package.json
+++ b/modules/demo/luma/lessons/08/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-08",
   "scripts": {

--- a/modules/demo/luma/lessons/09/package.json
+++ b/modules/demo/luma/lessons/09/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-09",
   "scripts": {

--- a/modules/demo/luma/lessons/10/package.json
+++ b/modules/demo/luma/lessons/10/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-10",
   "description": "The classic WebGL Lesson 10 ported to luma.gl.",

--- a/modules/demo/luma/lessons/11/package.json
+++ b/modules/demo/luma/lessons/11/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-11",
   "description": "The classic WebGL Lesson 11 ported to luma.gl.",

--- a/modules/demo/luma/lessons/12/package.json
+++ b/modules/demo/luma/lessons/12/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-12",
   "description": "The classic WebGL Lesson 12 ported to luma.gl.",

--- a/modules/demo/luma/lessons/13/package.json
+++ b/modules/demo/luma/lessons/13/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-13",
   "description": "The classic WebGL Lesson 13 ported to luma.gl.",

--- a/modules/demo/luma/lessons/14/package.json
+++ b/modules/demo/luma/lessons/14/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-14",
   "description": "The classic WebGL Lesson 14 ported to luma.gl.",

--- a/modules/demo/luma/lessons/15/package.json
+++ b/modules/demo/luma/lessons/15/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-15",
   "description": "The classic WebGL Lesson 15 ported to luma.gl.",

--- a/modules/demo/luma/lessons/16/package.json
+++ b/modules/demo/luma/lessons/16/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-16",
   "scripts": {

--- a/modules/demo/luma/package.json
+++ b/modules/demo/luma/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons",
   "main": "index.js",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/spatial/index.js
+++ b/modules/demo/spatial/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2021, NVIDIA CORPORATION.
 //

--- a/modules/demo/spatial/package.json
+++ b/modules/demo/spatial/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@rapidsai/demo-spatial",
   "main": "index.js",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/sql/sql-cluster-server/package.json
+++ b/modules/demo/sql/sql-cluster-server/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rapidsai/demo-sql-cluster-server",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/ssr/graph/index.js
+++ b/modules/demo/ssr/graph/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2021, NVIDIA CORPORATION.
 //

--- a/modules/demo/ssr/graph/package.json
+++ b/modules/demo/ssr/graph/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@rapidsai/demo-graph-ssr",
   "main": "index.js",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/ssr/luma/index.js
+++ b/modules/demo/ssr/luma/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2021, NVIDIA CORPORATION.
 //

--- a/modules/demo/ssr/luma/package.json
+++ b/modules/demo/ssr/luma/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@rapidsai/demo-luma.gl-lessons-ssr",
   "main": "index.js",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [
@@ -17,7 +17,7 @@
     "@rapidsai/cuda": "0.0.1",
     "@rapidsai/deck.gl": "0.0.1",
     "@rapidsai/jsdom": "0.0.1",
-    "@rapidsai/demo-luma.gl-lessons": "0.0.0",
+    "@rapidsai/demo-luma.gl-lessons": "0.0.1",
     "nanoid": "3.1.25",
     "simple-peer": "9.11.0",
     "fastify": "3.20.2",

--- a/modules/demo/tfjs/addition-rnn/index.js
+++ b/modules/demo/tfjs/addition-rnn/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2021, NVIDIA CORPORATION.
 //

--- a/modules/demo/tfjs/addition-rnn/package.json
+++ b/modules/demo/tfjs/addition-rnn/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@rapidsai/demo-tfjs-addition-rnn",
   "main": "index.js",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/tfjs/webgl-tests/package.json
+++ b/modules/demo/tfjs/webgl-tests/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@rapidsai/demo-tfjs-webgl-tests",
   "main": "index.js",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/umap/index.js
+++ b/modules/demo/umap/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020-2021, NVIDIA CORPORATION.
 //

--- a/modules/demo/umap/package.json
+++ b/modules/demo/umap/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@rapidsai/demo-umap",
   "main": "index.js",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/viz-app/package.json
+++ b/modules/demo/viz-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rapidsai/demo-viz-app",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/demo/xterm/index.js
+++ b/modules/demo/xterm/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules --trace-uncaught
+#!/usr/bin/env node
 
 // Copyright (c) 2020-2021, NVIDIA CORPORATION.
 //

--- a/modules/demo/xterm/package.json
+++ b/modules/demo/xterm/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@rapidsai/demo-xterm",
   "main": "index.js",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "author": "NVIDIA, Inc. (https://nvidia.com/)",
   "maintainers": [

--- a/modules/jsdom/src/polyfills/glfw.ts
+++ b/modules/jsdom/src/polyfills/glfw.ts
@@ -693,8 +693,8 @@ export function installGLFWWindow(windowOptions: GLFWWindowOptions = {}) {
         glfw.swapInterval(window.swapInterval);
         glfw.swapBuffers(window.id);
         window.poll();
-      } catch (e) {
-        console.error(`Error creating GLFW window:\n${Object.prototype.toString.call(e)}`);
+      } catch (e: any) {
+        console.error(`Error creating GLFW window:\n${String(e && e.stack || e)}`);
         window.destroyGLFWWindow();
         throw e;
       }

--- a/modules/rmm/CMakeLists.txt
+++ b/modules/rmm/CMakeLists.txt
@@ -24,7 +24,7 @@ unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(DISABLE_DEPRECATION_WARNINGS "Disable warnings generated from deprecated declarations." ON)
 
-set(RMM_VERSION "21.12.00")
+set(RMM_VERSION "22.02.00")
 
 ###################################################################################################
 # - cmake modules ---------------------------------------------------------------------------------

--- a/modules/sql/CMakeLists.txt
+++ b/modules/sql/CMakeLists.txt
@@ -25,9 +25,9 @@ unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY CACHE)
 option(NODE_RAPIDS_USE_SCCACHE "Enable caching compilation results with sccache" ON)
 option(DISABLE_DEPRECATION_WARNINGS "Disable warnings generated from deprecated declarations." ON)
 
-set(RMM_VERSION "21.12.00")
-set(CUDF_VERSION "21.12.00")
-set(BLAZINGSQL_VERSION "21.12.00")
+set(RMM_VERSION "22.02.00")
+set(CUDF_VERSION "22.02.00")
+set(BLAZINGSQL_VERSION "22.02.00")
 
 ###################################################################################################
 # - cmake modules ---------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "docker:build:devel:packages": "touch .env && npx cross-env DOCKER_BUILDKIT=1 DOCKER_SCAN_SUGGEST=false docker-compose -f docker-compose.devel.yml build --force-rm packages",
     "docker:build:devel:notebook": "touch .env && npx cross-env DOCKER_BUILDKIT=1 DOCKER_SCAN_SUGGEST=false docker-compose -f docker-compose.devel.yml build --force-rm notebook",
     "docker:build:runtime": "yarn docker:build:runtime:base && yarn docker:build:devel:packages && yarn docker:build:runtime:libraries && yarn docker:build:runtime:notebook",
-    "docker:build:runtime:base": "touch .env && npx cross-env DOCKER_BUILDKIT=1 DOCKER_SCAN_SUGGEST=false docker-compose -f docker-compose.runtime.yml build --force-rm --parallel cuda-base cudagl-base",
+    "docker:build:runtime:base": "touch .env && npx cross-env DOCKER_BUILDKIT=1 DOCKER_SCAN_SUGGEST=false docker-compose -f docker-compose.runtime.yml build --force-rm base",
     "docker:build:runtime:libraries": "touch .env && npx cross-env DOCKER_BUILDKIT=1 DOCKER_SCAN_SUGGEST=false docker-compose -f docker-compose.runtime.yml build --force-rm --parallel main demo glfw cudf sql cuml cugraph cuspatial",
     "docker:build:runtime:notebook": "touch .env && npx cross-env DOCKER_BUILDKIT=1 DOCKER_SCAN_SUGGEST=false docker-compose -f docker-compose.runtime.yml build --force-rm notebook",
     "docker:run:devel:notebook": "touch .env && docker-compose -f docker-compose.devel.yml run --rm -u $(id -u):$(id -g) notebook",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,9 +17,9 @@
     "@babel/highlight" "^7.16.0"
 
 "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.15.0", "@babel/compat-data@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.0.tgz#ea269d7f78deb3a7826c39a4048eecda541ebdaa"
-  integrity sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew==
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz#081d6bbc336ec5c2435c6346b2ae1fb98b5ac68e"
+  integrity sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==
 
 "@babel/core@7.15.5":
   version "7.15.5"
@@ -201,10 +201,10 @@
   resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
   integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
 
-"@babel/helper-remap-async-to-generator@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.0.tgz#d5aa3b086e13a5fe05238ff40c3a5a0c2dab3ead"
-  integrity sha512-MLM1IOMe9aQBqMWxcRw8dcb9jlM86NIw7KA0Wri91Xkfied+dE0QuBFSBjMNvqzmS0OSIDsMNC24dBEkPUi7ew==
+"@babel/helper-remap-async-to-generator@^7.16.0", "@babel/helper-remap-async-to-generator@^7.16.4":
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.4.tgz#5d7902f61349ff6b963e07f06a389ce139fbfe6e"
+  integrity sha512-vGERmmhR+s7eH5Y/cp8PCVzj4XEjerq8jooMfxFdA5xVtAk9Sh4AQsrWgiErUEBjtGrBtOFKDUcWQFW4/dFwMA==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.0"
     "@babel/helper-wrap-function" "^7.16.0"
@@ -280,9 +280,9 @@
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.15.5", "@babel/parser@^7.16.0", "@babel/parser@^7.16.3":
-  version "7.16.3"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.16.3.tgz#271bafcb811080905a119222edbc17909c82261d"
-  integrity sha512-dcNwU1O4sx57ClvLBVFbEgx0UZWfd0JQX5X6fxFRCLHelFBGXFfSz6Y0FAq2PEwUqlqLkdVjVr4VASEOuUnLJw==
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz#d5f92f57cf2c74ffe9b37981c0e72fee7311372e"
+  integrity sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.15.4":
   version "7.16.0"
@@ -294,12 +294,12 @@
     "@babel/plugin-proposal-optional-chaining" "^7.16.0"
 
 "@babel/plugin-proposal-async-generator-functions@^7.15.4":
-  version "7.16.0"
-  resolved "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.0.tgz#11425d47a60364352f668ad5fbc1d6596b2c5caf"
-  integrity sha512-nyYmIo7ZqKsY6P4lnVmBlxp9B3a96CscbLotlsNuktMHahkDwoPYEjXrZHU0Tj844Z9f1IthVxQln57mhkcExw==
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.4.tgz#e606eb6015fec6fa5978c940f315eae4e300b081"
+  integrity sha512-/CUekqaAaZCQHleSK/9HajvcD/zdnJiKRiuUFq8ITE+0HsPzquf53cpFiqAwl/UfmJbR6n5uGPQSPdrmKOvHHg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
-    "@babel/helper-remap-async-to-generator" "^7.16.0"
+    "@babel/helper-remap-async-to-generator" "^7.16.4"
     "@babel/plugin-syntax-async-generators" "^7.8.4"
 
 "@babel/plugin-proposal-class-properties@^7.14.5":
@@ -2210,7 +2210,7 @@
     "@math.gl/core" "^3.5.1"
     "@math.gl/geospatial" "^3.5.1"
 
-"@loaders.gl/core@3.0.12", "@loaders.gl/core@^3.0.8":
+"@loaders.gl/core@3.0.12", "@loaders.gl/core@3.0.13", "@loaders.gl/core@^3.0.8":
   version "3.0.12"
   resolved "https://registry.npmjs.org/@loaders.gl/core/-/core-3.0.12.tgz#2dcde94e1382d846db8c5ac803a44e195f28b40c"
   integrity sha512-+y7NaFUvnQtMt80UCj9D1vP23WSEKNibbMRNp1XavUdR+cCjjXpG4Rxl02eUmkv79V8wTXCawj2hKNFtURuXyw==
@@ -2239,13 +2239,13 @@
     "@loaders.gl/worker-utils" "3.0.12"
     draco3d "1.4.1"
 
-"@loaders.gl/gis@3.0.12", "@loaders.gl/gis@^3.0.8":
-  version "3.0.12"
-  resolved "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.0.12.tgz#19c33da7f2d4da9275a7a1a08e196182be718b69"
-  integrity sha512-NdEhcoubp/MJxNNserY7WHXCBbRCoZXZEuhK8sua7B6WWAAm5Mlv2dCV+HaLLPDG8rQSOWXJb3hqDpwsNY1/uQ==
+"@loaders.gl/gis@3.0.13", "@loaders.gl/gis@^3.0.8":
+  version "3.0.13"
+  resolved "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.0.13.tgz#b6b9729cde0cfdf8dc14cac6ccf49bac9b453299"
+  integrity sha512-pftgUaKJ65gFwNyi+a2NGwjW8M5FlLZYnhKHjQ5/lNMYsodwSxp7HrJR5RKON+x6P7gaxjBgoCMDrAgWKNCDHQ==
   dependencies:
-    "@loaders.gl/loader-utils" "3.0.12"
-    "@loaders.gl/schema" "3.0.12"
+    "@loaders.gl/loader-utils" "3.0.13"
+    "@loaders.gl/schema" "3.0.13"
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.2.1"
 
@@ -2277,7 +2277,7 @@
     "@math.gl/geospatial" "^3.5.1"
     probe.gl "^3.4.0"
 
-"@loaders.gl/images@3.0.12", "@loaders.gl/images@^3.0.8":
+"@loaders.gl/images@3.0.12", "@loaders.gl/images@3.0.13", "@loaders.gl/images@^3.0.8":
   version "3.0.12"
   resolved "https://registry.npmjs.org/@loaders.gl/images/-/images-3.0.12.tgz#06a823bcb82fb7c5b8b31bf26da4e3eb6e233d57"
   integrity sha512-L6xu2r5yavl7qTKP8AuE4C55xCaEa5xrIgekGIc6fk9y28kIwg1B20Uxj3f7H6giH/OXpG9a4gHqtR23KzlXcw==
@@ -2293,13 +2293,22 @@
     "@loaders.gl/loader-utils" "3.0.12"
     "@loaders.gl/schema" "3.0.12"
 
-"@loaders.gl/loader-utils@3.0.12", "@loaders.gl/loader-utils@^3.0.8":
+"@loaders.gl/loader-utils@3.0.12":
   version "3.0.12"
   resolved "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.0.12.tgz#8bf868a1a1a0eead0bbef6c0321622127e2f7dc2"
   integrity sha512-J2cYU8d5mx/rDoKdl6SlvoyvO1PXNi6Upul1OGCDql7S/mq+M9afsvNmRraZJOzcoO5NuWq30Eoh3rWD2w5Mew==
   dependencies:
     "@babel/runtime" "^7.3.1"
     "@loaders.gl/worker-utils" "3.0.12"
+    "@probe.gl/stats" "^3.4.0"
+
+"@loaders.gl/loader-utils@3.0.13", "@loaders.gl/loader-utils@^3.0.8":
+  version "3.0.13"
+  resolved "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.0.13.tgz#d6970a00ddea775e9e80d3617bbd4ad2ef12a1b8"
+  integrity sha512-tVDmytWaO1XHBV9F5UEQd55vAdnVDZhK2nUKY5oBfDlo1mG5PhXWOj2Za+yV4btMC86PWXYhLiUUgy+9vABPOw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@loaders.gl/worker-utils" "3.0.13"
     "@probe.gl/stats" "^3.4.0"
 
 "@loaders.gl/math@3.0.12":
@@ -2311,13 +2320,22 @@
     "@loaders.gl/loader-utils" "3.0.12"
     "@math.gl/core" "^3.5.1"
 
-"@loaders.gl/mvt@^3.0.8":
-  version "3.0.12"
-  resolved "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.0.12.tgz#3e969ea39fe92ff0daf1422a877f4152a7f0a98a"
-  integrity sha512-MIhw8rlIl8MOJ8pmI8pCVPg3ZTKoxD+NGa7So56zXzWwhMNjYj9ddlxcTkkJBqILSZUvTce4rmfGJ388Ms5mUA==
+"@loaders.gl/math@3.0.13":
+  version "3.0.13"
+  resolved "https://registry.npmjs.org/@loaders.gl/math/-/math-3.0.13.tgz#9385b476e4123bfb7572370e27fa00511314ca39"
+  integrity sha512-FMqJrOgO6IYxSW6ZhHpLKCLeP/1f4ASFZzo6J9CdON1MHv4YJ8jc1hDlDaiRDnOEl6ANCHvuSSVjUt9ML/XXgw==
   dependencies:
-    "@loaders.gl/gis" "3.0.12"
-    "@loaders.gl/loader-utils" "3.0.12"
+    "@loaders.gl/images" "3.0.13"
+    "@loaders.gl/loader-utils" "3.0.13"
+    "@math.gl/core" "^3.5.1"
+
+"@loaders.gl/mvt@^3.0.8":
+  version "3.0.13"
+  resolved "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.0.13.tgz#9887822fef8b92554c3452edc392b915bd618cc7"
+  integrity sha512-bo7ObDohK7sBlk4Y1WUjg8X2HQ6O9UaxhUmkJruceCtRpy1h7lqOEtxfwdFHXPWGCEUz27zhkk2dNtV8HffAbg==
+  dependencies:
+    "@loaders.gl/gis" "3.0.13"
+    "@loaders.gl/loader-utils" "3.0.13"
     "@math.gl/polygon" "^3.5.1"
     pbf "^3.2.1"
 
@@ -2349,14 +2367,23 @@
     apache-arrow "^4.0.0"
     d3-dsv "^1.2.0"
 
+"@loaders.gl/schema@3.0.13":
+  version "3.0.13"
+  resolved "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.0.13.tgz#10a9d5b0b76bade1b7a68f0729795ef6a1726186"
+  integrity sha512-w6jPTnaSE/d5EfIKSVNRGFxUb56EiJrbKBUbZ6OgRkBlDlmSbLvRoaH/Jz5TT8ewK7DF6pumMqTXJ/0n0SZ5Pw==
+  dependencies:
+    "@types/geojson" "^7946.0.7"
+    apache-arrow "^4.0.0"
+    d3-dsv "^1.2.0"
+
 "@loaders.gl/terrain@^3.0.8":
-  version "3.0.12"
-  resolved "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.0.12.tgz#0e2a266daccaf4fd5eea1032c7823b823f026705"
-  integrity sha512-N96ZT5U6FFN+Tdx5VoXW7fY9baq8B0vnZbEsSZ+cBOvpOa+ifAoflCC67hN35/EX2SzJzHAMdVfALjCqJJHcLQ==
+  version "3.0.13"
+  resolved "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.0.13.tgz#a90e7bd36121cc748ef5ab56a031ce4743050b7e"
+  integrity sha512-trUnxKFWGuHonIrQy4DvNjtRZZ+qgymS9xqKe3iZ7wqu9Ho/7ZbdnPzt75vIM1QQiDHSNiccBsq2Nr8g1BDuXg==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    "@loaders.gl/loader-utils" "3.0.12"
-    "@loaders.gl/schema" "3.0.12"
+    "@loaders.gl/loader-utils" "3.0.13"
+    "@loaders.gl/schema" "3.0.13"
     "@mapbox/martini" "^0.2.0"
 
 "@loaders.gl/textures@3.0.12":
@@ -2370,7 +2397,7 @@
     ktx-parse "^0.0.4"
     texture-compressor "^1.0.2"
 
-"@loaders.gl/tiles@3.0.12", "@loaders.gl/tiles@^3.0.8":
+"@loaders.gl/tiles@3.0.12":
   version "3.0.12"
   resolved "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.0.12.tgz#48127eebabf44ebfcabbca4740390e3e8c74d1d7"
   integrity sha512-/FvLpssIycvpXOVvmlubFrLlWe7VI3YYrue8wbmlKk7cndCWjCPP7feyg87EF4XlXOC7r3AleiF3Z1R6aADcTA==
@@ -2384,10 +2411,31 @@
     "@math.gl/web-mercator" "^3.5.1"
     "@probe.gl/stats" "^3.4.0"
 
+"@loaders.gl/tiles@^3.0.8":
+  version "3.0.13"
+  resolved "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.0.13.tgz#0d96d9a524b5f9aedfcf7ad40a629a308af2258f"
+  integrity sha512-mkbBIEXsVVEsVpkXkQrATG25Iw3lYaeHMVem4xCpCHQHV5d8cFyLnXBzWi/cWRzfEk+dAMT7g+LkxH39rG43og==
+  dependencies:
+    "@loaders.gl/core" "3.0.13"
+    "@loaders.gl/loader-utils" "3.0.13"
+    "@loaders.gl/math" "3.0.13"
+    "@math.gl/core" "^3.5.1"
+    "@math.gl/culling" "^3.5.1"
+    "@math.gl/geospatial" "^3.5.1"
+    "@math.gl/web-mercator" "^3.5.1"
+    "@probe.gl/stats" "^3.4.0"
+
 "@loaders.gl/worker-utils@3.0.12":
   version "3.0.12"
   resolved "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.0.12.tgz#acde5f5f6e5afaec3f995f892fb6e34e5a1629d1"
   integrity sha512-xbZiYxGNLniXrCMNyvyw91I+DCOrclHc3mwtCPZaJQi+eEFaq0Kh7Lv9yUCE6cCgDLNJfjcfmbcyCBgwlvq7WA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+
+"@loaders.gl/worker-utils@3.0.13":
+  version "3.0.13"
+  resolved "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.0.13.tgz#861f6ec62a617fb8eacd36f98c9f70b87782ef28"
+  integrity sha512-QB4jZumKGsouJprPzNKnKXTXMLf89afBwmi4Rnnw4SVj49olPiAGh4FZjf00GHFHKZlvAj8LB5rfqwd+Te6IVA==
   dependencies:
     "@babel/runtime" "^7.3.1"
 
@@ -2486,16 +2534,16 @@
   integrity sha512-7hFhtkb0KTLEls+TRw/rWayq5EeHtTaErgm/NskVoXmtgAQu/9D299aeyj6mzAR/6XUnYRp2lU+4IcrYRFjVsQ==
 
 "@mapbox/node-pre-gyp@^1.0.0":
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.6.tgz#f859d601a210537e27530f363028cde56e0cf962"
-  integrity sha512-qK1ECws8UxuPqOA8F5LFD90vyVU33W7N3hGfgsOVfrJaRVc8McC3JClTDHpeSbL9CBrOHly/4GsNPAvIgNZE+g==
+  version "1.0.7"
+  resolved "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.7.tgz#a26919cac6595662703330d1820a0ca206f45521"
+  integrity sha512-PplSvl4pJ5N3BkVjAdDzpPhVUPdC73JgttkR+LnBx2OORC1GCQsBjUeEuipf9uOaAM1SbxcdZFfR3KDTKm2S0A==
   dependencies:
     detect-libc "^1.0.3"
     https-proxy-agent "^5.0.0"
     make-dir "^3.1.0"
     node-fetch "^2.6.5"
     nopt "^5.0.0"
-    npmlog "^5.0.1"
+    npmlog "^6.0.0"
     rimraf "^3.0.2"
     semver "^7.3.5"
     tar "^6.1.11"
@@ -3159,9 +3207,9 @@
     form-data "^3.0.0"
 
 "@types/node@*", "@types/node@>= 8", "@types/node@>=10.0.0":
-  version "16.11.7"
-  resolved "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz#36820945061326978c42a01e56b61cd223dfdc42"
-  integrity sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==
+  version "16.11.9"
+  resolved "https://registry.npmjs.org/@types/node/-/node-16.11.9.tgz#879be3ad7af29f4c1a5c433421bf99fab7047185"
+  integrity sha512-MKmdASMf3LtPzwLyRrFjtFFZ48cMf8jmX5VRYrDQiJa8Ybu5VAmkqBWqKU8fdCwD8ysw4mQ9nrEHvzg6gunR7A==
 
 "@types/node@^13.7.4":
   version "13.13.52"
@@ -3169,9 +3217,9 @@
   integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
 
 "@types/node@^14.14.37":
-  version "14.17.33"
-  resolved "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz#011ee28e38dc7aee1be032ceadf6332a0ab15b12"
-  integrity sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g==
+  version "14.17.34"
+  resolved "https://registry.npmjs.org/@types/node/-/node-14.17.34.tgz#fe4b38b3f07617c0fa31ae923fca9249641038f0"
+  integrity sha512-USUftMYpmuMzeWobskoPfzDi+vkpe0dvcOBRNOscFrGxVp4jomnRxWuVohgqBow2xyIPC0S3gjxV/5079jhmDg==
 
 "@types/node@^15.0.0":
   version "15.14.9"
@@ -3199,9 +3247,9 @@
   integrity sha512-+hQX+WyJAOne7Fh3zF5CxPemILIbuhNcqHHodzK9caYOLnC8pD5efmPleRnw0z++LfKUC/sVNMwk0Gap+B0baA==
 
 "@types/prettier@^2.0.0":
-  version "2.4.1"
-  resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz#e1303048d5389563e130f5bdd89d37a99acb75eb"
-  integrity sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==
+  version "2.4.2"
+  resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz#4c62fae93eb479660c3bd93f9d24d561597a8281"
+  integrity sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==
 
 "@types/prop-types@*", "@types/prop-types@^15.7.3":
   version "15.7.4"
@@ -3221,9 +3269,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@>=16.14.8", "@types/react@>=16.9.11":
-  version "17.0.34"
-  resolved "https://registry.npmjs.org/@types/react/-/react-17.0.34.tgz#797b66d359b692e3f19991b6b07e4b0c706c0102"
-  integrity sha512-46FEGrMjc2+8XhHXILr+3+/sTe3OfzSPU9YGKILLrUYbQ1CLQC9Daqo1KzENGXAWwrFwiY0l4ZbF20gRvgpWTg==
+  version "17.0.35"
+  resolved "https://registry.npmjs.org/@types/react/-/react-17.0.35.tgz#217164cf830267d56cd1aec09dcf25a541eedd4c"
+  integrity sha512-r3C8/TJuri/SLZiiwwxQoLAoavaczARfT9up9b4Jr65+ErAUX3MIkU0oMOQnrpfgHme8zIqZLX7O5nnjm5Wayw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -3422,9 +3470,9 @@ acorn@^7.1.1, acorn@^7.4.0:
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 acorn@^8.2.4:
-  version "8.5.0"
-  resolved "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
-  integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
+  version "8.6.0"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
+  integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
 
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"
@@ -3473,9 +3521,9 @@ ajv@^6.10.0, ajv@^6.11.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.6:
     uri-js "^4.2.2"
 
 ajv@^8.0.1, ajv@^8.1.0:
-  version "8.7.1"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.7.1.tgz#52be6f1736b076074798124293618f132ad07a7e"
-  integrity sha512-gPpOObTO1QjbnN1sVMjJcp1TF9nggMfO4MBR5uQl6ZVTOaEPq5i4oq/6R9q2alMMPB3eg53wFv1RuJBLuxf3Hw==
+  version "8.8.1"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.8.1.tgz#e73dd88eeb4b10bbcd82bee136e6fbe801664d18"
+  integrity sha512-6CiMNDrzv0ZR916u2T+iRunnD60uWmNn8SkdB44/6stVORUg0aAkWO7PkOhpCmjmW8f2I/G/xnowD66fxGyQJg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -4226,12 +4274,12 @@ browserslist@4.16.6:
     node-releases "^1.1.71"
 
 browserslist@^4.17.5, browserslist@^4.17.6:
-  version "4.17.6"
-  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.17.6.tgz#c76be33e7786b497f66cad25a73756c8b938985d"
-  integrity sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==
+  version "4.18.1"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz#60d3920f25b6860eb917c6c7b185576f4d8b017f"
+  integrity sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==
   dependencies:
-    caniuse-lite "^1.0.30001274"
-    electron-to-chromium "^1.3.886"
+    caniuse-lite "^1.0.30001280"
+    electron-to-chromium "^1.3.896"
     escalade "^3.1.1"
     node-releases "^2.0.1"
     picocolors "^1.0.0"
@@ -4457,14 +4505,14 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 camelcase@^6.0.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
-  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz#250fd350cfd555d0d2160b1d51510eaf8326e86e"
+  integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
 
-caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001274:
-  version "1.0.30001279"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz#eb06818da481ef5096a3b3760f43e5382ed6b0ce"
-  integrity sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==
+caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001280:
+  version "1.0.30001282"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz#38c781ee0a90ccfe1fe7fefd00e43f5ffdcb96fd"
+  integrity sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==
 
 canvas@2.8.0, canvas@^2.6.0:
   version "2.8.0"
@@ -5353,14 +5401,14 @@ cssstyle@^2.3.0:
     cssom "~0.3.6"
 
 csstype@^2.5.2, csstype@^2.5.7:
-  version "2.6.18"
-  resolved "https://registry.npmjs.org/csstype/-/csstype-2.6.18.tgz#980a8b53085f34af313410af064f2bd241784218"
-  integrity sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ==
+  version "2.6.19"
+  resolved "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz#feeb5aae89020bb389e1f63669a5ed490e391caa"
+  integrity sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==
 
 csstype@^3.0.2:
-  version "3.0.9"
-  resolved "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
-  integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
+  version "3.0.10"
+  resolved "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
+  integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -6109,10 +6157,10 @@ ee-first@1.1.1:
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.723, electron-to-chromium@^1.3.886:
-  version "1.3.895"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.895.tgz#9b0f8f2e32d8283bbb200156fd5d8dfd775f31ed"
-  integrity sha512-9Ww3fB8CWctjqHwkOt7DQbMZMpal2x2reod+/lU4b9axO1XJEDUpPMBxs7YnjLhhqpKXIIB5SRYN/B4K0QpvyQ==
+electron-to-chromium@^1.3.723, electron-to-chromium@^1.3.896:
+  version "1.3.903"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.903.tgz#e2d3c3809f4ef05fdbe5cc88969dfc94b1bd15b9"
+  integrity sha512-+PnYAyniRRTkNq56cqYDLq9LyklZYk0hqoDy9GpcU11H5QjRmFZVDbxtgHUMK/YzdNTcn1XWP5gb+hFlSCr20g==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -6203,9 +6251,9 @@ engine.io-parser@~4.0.0, engine.io-parser@~4.0.1:
     base64-arraybuffer "0.1.4"
 
 engine.io-parser@~5.0.0:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.1.tgz#6695fc0f1e6d76ad4a48300ff80db5f6b3654939"
-  integrity sha512-j4p3WwJrG2k92VISM0op7wiq60vO92MlF3CRGxhKHy9ywG1/Dkc72g0dXeDQ+//hrcDn8gqQzoEkdO9FN0d9AA==
+  version "5.0.2"
+  resolved "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.2.tgz#69a2ec3ed431da021f0666712d07f106bcffa6ce"
+  integrity sha512-wuiO7qO/OEkPJSFueuATIXtrxF7/6GTbAO9QLv7nnbjwZ5tYhLm9zxvLwxstRs0dcT0KUlWTjtIOs1T86jt12g==
   dependencies:
     base64-arraybuffer "~1.0.1"
 
@@ -6222,10 +6270,10 @@ engine.io@~5.1.1:
     engine.io-parser "~4.0.0"
     ws "~7.4.2"
 
-engine.io@~6.0.0:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/engine.io/-/engine.io-6.0.1.tgz#4a37754c6067415e9bfbcc82e49e572437354615"
-  integrity sha512-Y53UaciUh2Rmx5MiogtMxOQcfh7pnemday+Bb4QDg0Wjmnvo/VTvuEyNGQgYmh8L7VOe8Je1QuiqjLNDelMqLA==
+engine.io@~6.1.0:
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/engine.io/-/engine.io-6.1.0.tgz#459eab0c3724899d7b63a20c3a6835cf92857939"
+  integrity sha512-ErhZOVu2xweCjEfYcTdkCnEYUiZgkAcBBAhW4jbIvNG8SLU3orAqoJCiytZjYF7eTpVmmCrLDjLIEaPlUAs1uw==
   dependencies:
     "@types/cookie" "^0.4.1"
     "@types/cors" "^2.8.12"
@@ -6934,9 +6982,9 @@ find-java-home@1.1.0:
     winreg "~1.2.2"
 
 find-my-way@^4.1.0:
-  version "4.3.3"
-  resolved "https://registry.npmjs.org/find-my-way/-/find-my-way-4.3.3.tgz#2ab3880a03bcaa8594548d66b0cd1c5a6e98dd44"
-  integrity sha512-5E4bRdaATB1MewjOCBjx4xvD205a4t2ripCnXB+YFhYEJ0NABtrcC7XLXLq0TPoFe/WYGUFqys3Qk3HCOGeNcw==
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/find-my-way/-/find-my-way-4.4.0.tgz#e4a115031d1c5c538d028d06b666e2174462bc07"
+  integrity sha512-hpntHvK0iOHp3pqWRRUEzioar4tp8euBD8DkPG3VauOriZLgwGZLTNp6yZSrdctJ8RCDS7zhZSR2V+yOaBbNow==
   dependencies:
     fast-decode-uri-component "^1.0.1"
     fast-deep-equal "^3.1.3"
@@ -7164,19 +7212,19 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-gauge@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz#4bea07bcde3782f06dced8950e51307aa0f4a346"
-  integrity sha512-6STz6KdQgxO4S/ko+AbjlFGGdGcknluoqU+79GOFCDqqyYj5OanQf9AjxwN0jCidtT+ziPMmPSt9E4hfQ0CwIQ==
+gauge@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/gauge/-/gauge-4.0.0.tgz#afba07aa0374a93c6219603b1fb83eaa2264d8f8"
+  integrity sha512-F8sU45yQpjQjxKkm1UOAhf0U/O0aFt//Fl7hsrNVto+patMHjs7dPI9mFOGUKbhrgKm0S3EjW3scMFuQmWSROw==
   dependencies:
+    ansi-regex "^5.0.1"
     aproba "^1.0.3 || ^2.0.0"
     color-support "^1.1.2"
     console-control-strings "^1.0.0"
     has-unicode "^2.0.1"
-    object-assign "^4.1.1"
     signal-exit "^3.0.0"
-    string-width "^1.0.1 || ^2.0.0"
-    strip-ansi "^3.0.1 || ^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
     wide-align "^1.1.2"
 
 gauge@~1.2.0:
@@ -9317,9 +9365,9 @@ listenercount@~1.0.1:
   integrity sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=
 
 listr2@^3.2.2:
-  version "3.13.3"
-  resolved "https://registry.npmjs.org/listr2/-/listr2-3.13.3.tgz#d8f6095c9371b382c9b1c2bc33c5941d8e177f11"
-  integrity sha512-VqAgN+XVfyaEjSaFewGPcDs5/3hBbWVaX1VgWv2f52MF7US45JuARlArULctiB44IIcEk3JF7GtoFCLqEdeuPA==
+  version "3.13.4"
+  resolved "https://registry.npmjs.org/listr2/-/listr2-3.13.4.tgz#34101fc0184545597e00d1e7915ccfbfb17332e6"
+  integrity sha512-lZ1Rut1DSIRwbxQbI8qaUBfOWJ1jEYRgltIM97j6kKOCI2pHVWMyxZvkU/JKmRBWcIYgDS2PK+yDgVqm7u3crw==
   dependencies:
     cli-truncate "^2.1.0"
     clone "^2.1.2"
@@ -10444,14 +10492,14 @@ npmlog@^4.1.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-npmlog@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz#f06678e80e29419ad67ab964e0fa69959c1eb8b0"
-  integrity sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
+npmlog@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/npmlog/-/npmlog-6.0.0.tgz#ba9ef39413c3d936ea91553db7be49c34ad0520c"
+  integrity sha512-03ppFRGlsyUaQFbGC2C8QWJN/C/K7PsfyD9aQdhVKAQIH4sQBc8WASqFBP7O+Ut4d2oo5LoeoboB3cGdBZSp6Q==
   dependencies:
     are-we-there-yet "^2.0.0"
     console-control-strings "^1.1.0"
-    gauge "^3.0.0"
+    gauge "^4.0.0"
     set-blocking "^2.0.0"
 
 number-is-nan@^1.0.0:
@@ -12455,9 +12503,9 @@ side-channel@^1.0.4:
     object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
-  version "3.0.5"
-  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz#9e3e8cc0c75a99472b44321033a7702e7738252f"
-  integrity sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==
+  version "3.0.6"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
+  integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
 
 simple-commit-message@4.0.3:
   version "4.0.3"
@@ -12595,10 +12643,10 @@ snapsvg@0.5.1:
   dependencies:
     eve "~0.5.1"
 
-socket.io-adapter@~2.3.1, socket.io-adapter@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.2.tgz#039cd7c71a52abad984a6d57da2c0b7ecdd3c289"
-  integrity sha512-PBZpxUPYjmoogY0aoaTmo1643JelsaS1CiAwNjRVdrI0X9Seuc19Y2Wife8k88avW6haG8cznvwbubAZwH4Mtg==
+socket.io-adapter@~2.3.1, socket.io-adapter@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz#4d6111e4d42e9f7646e365b4f578269821f13486"
+  integrity sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==
 
 socket.io-client@4.2.0:
   version "4.2.0"
@@ -12638,15 +12686,15 @@ socket.io@4.1.3:
     socket.io-parser "~4.0.4"
 
 socket.io@^4.0.1:
-  version "4.3.2"
-  resolved "https://registry.npmjs.org/socket.io/-/socket.io-4.3.2.tgz#85ae0cf5cf18acbce648ac9f48aba66df8cea6bf"
-  integrity sha512-6S5tV4jcY6dbZ/lLzD6EkvNWI3s81JO6ABP/EpvOlK1NPOcIj3AS4khi6xXw6JlZCASq82HQV4SapfmVMMl2dg==
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/socket.io/-/socket.io-4.4.0.tgz#8140a0db2c22235f88a6dceb867e4d5c9bd70507"
+  integrity sha512-bnpJxswR9ov0Bw6ilhCvO38/1WPtE3eA2dtxi2Iq4/sFebiDJQzgKNYA7AuVVdGW09nrESXd90NbZqtDd9dzRQ==
   dependencies:
     accepts "~1.3.4"
     base64id "~2.0.0"
     debug "~4.3.2"
-    engine.io "~6.0.0"
-    socket.io-adapter "~2.3.2"
+    engine.io "~6.1.0"
+    socket.io-adapter "~2.3.3"
     socket.io-parser "~4.0.4"
 
 socks-proxy-agent@^4.0.0:
@@ -12692,9 +12740,9 @@ source-map-resolve@^0.5.0:
     urix "^0.1.0"
 
 source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.20, source-map-support@^0.5.6:
-  version "0.5.20"
-  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz#12166089f8f5e5e8c56926b377633392dd2cb6c9"
-  integrity sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
+  version "0.5.21"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -12755,9 +12803,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.10"
-  resolved "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz#0d9becccde7003d6c658d487dd48a32f0bf3014b"
-  integrity sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==
+  version "3.0.11"
+  resolved "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz#50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95"
+  integrity sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==
 
 split-on-first@^1.0.0:
   version "1.1.0"
@@ -12965,14 +13013,6 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.1 || ^2.0.0", string-width@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
-  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
-  dependencies:
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^4.0.0"
-
 "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -12981,6 +13021,14 @@ string-width@^1.0.1:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string-width@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
 
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
@@ -13056,7 +13104,7 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
-"strip-ansi@^3.0.1 || ^4.0.0", strip-ansi@^4.0.0:
+strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=


### PR DESCRIPTION
Updates containers to all use CUDA 11.5.0, as cuDF no longer compiles w/ anything less.