### PR TITLE
Fix typedoc issues

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -52,7 +52,7 @@
     "shx": "0.3.3",
     "ts-jest": "26.5.3",
     "ts-node": "10.0.0",
-    "typedoc": "0.21.4",
+    "typedoc": "0.22.10",
     "typescript": "4.4.4"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "pre-git": "3.17.1",
     "rimraf": "3.0.0",
     "shx": "0.3.3",
-    "typedoc": "0.21.4"
+    "typedoc": "0.22.10"
   },
   "config": {
     "pre-git": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "include": [
         "modules/*/src/**/*.ts",
-        "modules/*/test/**/*.ts"
     ],
     "exclude": ["node_modules"],
     "compilerOptions": {

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,30 +1,22 @@
-const Path        = require('path');
-const loadOptions = (base) => {
-  const opts       = require(Path.resolve(base, 'typedoc.js'));
-  opts.entryPoints = opts.entryPoints.map((entryPoint) => Path.resolve(base, entryPoint));
-  return opts;
+module.exports = {
+  entryPoints: [
+    'modules/cuda/src/index.ts',
+    'modules/rmm/src/index.ts',
+    'modules/cudf/src/index.ts',
+    'modules/cuml/src/index.ts',
+    'modules/cugraph/src/index.ts',
+    'modules/cuspatial/src/index.ts',
+    'modules/deck.gl/src/index.ts',
+    'modules/glfw/src/index.ts',
+    'modules/webgl/src/index.ts',
+    'modules/sql/src/index.ts',
+    'modules/io/src/index.ts'
+  ],
+  out: 'doc',
+  name: 'RAPIDS',
+  tsconfig: 'tsconfig.json',
+  hideGenerator: true,
+  excludePrivate: true,
+  excludeProtected: true,
+  excludeExternals: true,
 };
-
-const mergeOptions = (...opts) => Object.assign(
-  {}, ...opts, {entryPoints: opts.reduce((es, {entryPoints = []}) => [...es, ...entryPoints], [])});
-
-module.exports = mergeOptions(loadOptions('modules/cuda'),
-                              loadOptions('modules/rmm'),
-                              loadOptions('modules/cudf'),
-                              loadOptions('modules/cuml'),
-                              loadOptions('modules/cugraph'),
-                              loadOptions('modules/cuspatial'),
-                              loadOptions('modules/deck.gl'),
-                              loadOptions('modules/glfw'),
-                              loadOptions('modules/webgl'),
-                              loadOptions('modules/sql'),
-                              loadOptions('modules/io'),
-                              {
-                                out: 'doc',
-                                name: 'RAPIDS',
-                                tsconfig: 'tsconfig.json',
-                                hideGenerator: true,
-                                excludePrivate: true,
-                                excludeProtected: true,
-                                excludeExternals: true,
-                              });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7523,7 +7523,7 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.7:
+glob@^7.0.0, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -7598,7 +7598,7 @@ hammerjs@^2.0.8:
   resolved "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
   integrity sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=
 
-handlebars@^4.7.6, handlebars@^4.7.7:
+handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -9757,10 +9757,10 @@ mapbox-gl@^1.0.0:
     tinyqueue "^2.0.3"
     vt-pbf "^3.1.1"
 
-marked@^2.1.1:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
-  integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
+marked@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz#2785f0dc79cbdc6034be4bb4f0f0a396bd3f8aeb"
+  integrity sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==
 
 material-ui-confirm@2.1.3:
   version "2.1.3"
@@ -9930,7 +9930,7 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.0, minimatch@^3.0.4:
+minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -11219,7 +11219,7 @@ process@0.11.10, process@^0.11.10:
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-progress@^2.0.0, progress@^2.0.3:
+progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -12493,7 +12493,7 @@ shellwords@^0.1.1:
   resolved "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shiki@^0.9.3:
+shiki@^0.9.12:
   version "0.9.15"
   resolved "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz#2481b46155364f236651319d2c18e329ead6fa44"
   integrity sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==
@@ -13760,24 +13760,16 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.12.10:
-  version "0.12.10"
-  resolved "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz#614c4222fe642657f37693ea62cad4dafeddf843"
-  integrity sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==
-
-typedoc@0.21.4:
-  version "0.21.4"
-  resolved "https://registry.npmjs.org/typedoc/-/typedoc-0.21.4.tgz#fced3cffdc30180db60a5dbfec9dbbb273cb5b31"
-  integrity sha512-slZQhvD9U0d9KacktYAyuNMMOXJRFNHy+Gd8xY2Qrqq3eTTTv3frv3N4au/cFnab9t3T5WA0Orb6QUjMc+1bDA==
+typedoc@0.22.10:
+  version "0.22.10"
+  resolved "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz#221e1a2b17bcb71817ef027dc4c4969d572e7620"
+  integrity sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==
   dependencies:
-    glob "^7.1.7"
-    handlebars "^4.7.7"
+    glob "^7.2.0"
     lunr "^2.3.9"
-    marked "^2.1.1"
-    minimatch "^3.0.0"
-    progress "^2.0.3"
-    shiki "^0.9.3"
-    typedoc-default-themes "^0.12.10"
+    marked "^3.0.8"
+    minimatch "^3.0.4"
+    shiki "^0.9.12"
 
 typescript@4.4.4:
   version "4.4.4"


### PR DESCRIPTION
This PR updates the typedoc version to latest, simplifies top level `typedoc.js` by explicitly listing the module entry points, and removes `*test/**` from `tsconfig.json` includes.