### PR TITLE
[FEA] Add image vendor and source so the containers are linked to our GH repo

### DIFF
--- a/.github/actions/build-and-publish-image/action.yml
+++ b/.github/actions/build-and-publish-image/action.yml
@@ -102,6 +102,9 @@ runs:
         tags: ${{ inputs.tags }}
         platforms: ${{ inputs.platforms }}
         build-args: ${{ inputs.build-args }}
+        labels: |
+          org.opencontainers.image.vendor=NVIDIA
+          org.opencontainers.image.source=https://github.com/rapidsai/node
         secret-files: |
           "sccache_credentials=/tmp/sccache_credentials"
     - name: Clean up


### PR DESCRIPTION
I noticed the containers stopped showing up in https://github.com/rapidsai/node/packages and https://github.com/orgs/rapidsai/packages?repo_name=node.

[This GH doc](https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package) says adding a label should link them to the repo again.