### PR TITLE
Automatically disposing scope

### DIFF
--- a/modules/cudf/src/column.cpp
+++ b/modules/cudf/src/column.cpp
@@ -29,6 +29,7 @@ Napi::Function Column::Init(Napi::Env const& env, Napi::Object exports) {
                        InstanceAccessor<&Column::type, &Column::type>("type"),
                        InstanceAccessor<&Column::data>("data"),
                        InstanceAccessor<&Column::null_mask>("mask"),
+                       InstanceAccessor<&Column::disposed>("disposed"),
                        InstanceAccessor<&Column::offset>("offset"),
                        InstanceAccessor<&Column::size>("length"),
                        InstanceAccessor<&Column::has_nulls>("hasNulls"),
@@ -308,6 +309,10 @@ void Column::dispose(Napi::Env env) {
 }
 
 void Column::dispose(Napi::CallbackInfo const& info) { dispose(info.Env()); }
+
+Napi::Value Column::disposed(Napi::CallbackInfo const& info) {
+  return Napi::Value::From(info.Env(), disposed_);
+}
 
 // If the null count is known, return it. Else, compute and return it
 cudf::size_type Column::null_count() const {

--- a/modules/cudf/src/column.cpp
+++ b/modules/cudf/src/column.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ Napi::Function Column::Init(Napi::Env const& env, Napi::Object exports) {
                        InstanceMethod<&Column::set_null_count>("setNullCount"),
                        // column/copying.cpp
                        InstanceMethod<&Column::gather>("gather"),
+                       InstanceMethod<&Column::apply_boolean_mask>("applyBooleanMask"),
                        InstanceMethod<&Column::copy>("copy"),
                        // column/filling.cpp
                        InstanceMethod<&Column::fill>("fill"),
@@ -458,7 +459,26 @@ Napi::Value Column::gather(Napi::CallbackInfo const& info) {
   if (!Column::IsInstance(info[0])) {
     throw Napi::Error::New(info.Env(), "gather selection argument expects a Column");
   }
-  return this->operator[](*Column::Unwrap(info[0].ToObject()));
+
+  CallbackArgs args{info};
+  Column::wrapper_t selection         = args[0].ToObject();
+  auto oob_policy                     = args[1].ToBoolean() ? cudf::out_of_bounds_policy::NULLIFY
+                                                            : cudf::out_of_bounds_policy::DONT_CHECK;
+  rmm::mr::device_memory_resource* mr = args[2];
+
+  return this->gather(selection, oob_policy, mr);
+}
+
+Napi::Value Column::apply_boolean_mask(Napi::CallbackInfo const& info) {
+  if (!Column::IsInstance(info[0])) {
+    throw Napi::Error::New(info.Env(), "gather selection argument expects a Column");
+  }
+
+  CallbackArgs args{info};
+  Column::wrapper_t selection         = args[0].ToObject();
+  rmm::mr::device_memory_resource* mr = args[1];
+
+  return this->apply_boolean_mask(selection, mr);
 }
 
 Napi::Value Column::get_child(Napi::CallbackInfo const& info) {

--- a/modules/cudf/src/column.cpp
+++ b/modules/cudf/src/column.cpp
@@ -476,7 +476,7 @@ Napi::Value Column::gather(Napi::CallbackInfo const& info) {
 
 Napi::Value Column::apply_boolean_mask(Napi::CallbackInfo const& info) {
   if (!Column::IsInstance(info[0])) {
-    throw Napi::Error::New(info.Env(), "gather selection argument expects a Column");
+    throw Napi::Error::New(info.Env(), "apply_boolean_mask selection argument expects a Column");
   }
 
   CallbackArgs args{info};

--- a/modules/cudf/src/column.ts
+++ b/modules/cudf/src/column.ts
@@ -132,6 +132,7 @@ export interface Column<T extends DataType = any> {
   readonly type: T;
   readonly data: DeviceBuffer;
   readonly mask: DeviceBuffer;
+  readonly disposed: boolean;
 
   readonly offset: number;
   readonly length: number;

--- a/modules/cudf/src/column.ts
+++ b/modules/cudf/src/column.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -146,11 +146,36 @@ export interface Column<T extends DataType = any> {
   dispose(): void;
 
   /**
+   * @summary Return sub-selection from a Column.
+   *
+   * @description Gathers the rows of the source columns according to `selection`, such that row "i"
+   * in the resulting Column's columns will contain row `selection[i]` from the source columns. The
+   * number of rows in the result column will be equal to the number of elements in selection. A
+   * negative value i in the selection is interpreted as i+n, where `n` is the number of rows in
+   * the source column.
+   *
+   * For dictionary columns, the keys column component is copied and not trimmed if the gather
+   * results in abandoned key elements.
+   *
+   * @param selection A Series of 8/16/32-bit signed or unsigned integer indices to gather.
+   * @param nullify_out_of_bounds If `true`, coerce rows that corresponds to out-of-bounds indices
+   *   in the selection to null. If `false`, skips all bounds checking for selection values. Pass
+   *   false if you are certain that the selection contains only valid indices for better
+   *   performance. If `false` and there are out-of-bounds indices in the selection, the behavior
+   *   is undefined. Defaults to `false`.
+   * @param memoryResource An optional MemoryResource used to allocate the result's device memory.
+   */
+  gather(selection: Column<IndexType>,
+         nullify_out_of_bounds: boolean,
+         memoryResource?: MemoryResource): Column<T>;
+
+  /**
    * Return sub-selection from a Column
    *
-   * @param selection
+   * @param selection A Series of bools.
+   * @param memoryResource An optional MemoryResource used to allocate the result's device memory.
    */
-  gather(selection: Column<IndexType|Bool8>): Column<T>;
+  applyBooleanMask(selection: Column<Bool8>, memoryResource?: MemoryResource): Column<T>;
 
   /**
    * Return a copy of a Column

--- a/modules/cudf/src/column/from_arrow.ts
+++ b/modules/cudf/src/column/from_arrow.ts
@@ -15,8 +15,29 @@
 import * as arrow from 'apache-arrow';
 
 import {Column} from '../column';
-import {Int32, Uint32, Uint8} from '../types/dtypes';
-import {arrowToCUDFType, ArrowToCUDFType} from '../types/mappings';
+import {
+  Bool8,
+  Categorical,
+  Float32,
+  Float64,
+  Int16,
+  Int32,
+  Int64,
+  Int8,
+  List,
+  Struct,
+  TimestampDay,
+  TimestampMicrosecond,
+  TimestampMillisecond,
+  TimestampNanosecond,
+  TimestampSecond,
+  Uint16,
+  Uint32,
+  Uint64,
+  Uint8,
+  Utf8String,
+} from '../types/dtypes';
+import {ArrowToCUDFType} from '../types/mappings';
 
 /** @ignore */
 interface VectorToColumnVisitor extends arrow.Visitor {
@@ -28,65 +49,55 @@ interface VectorToColumnVisitor extends arrow.Visitor {
 class VectorToColumnVisitor extends arrow.Visitor {
   // visitNull<T extends arrow.Null>(vector: arrow.Vector<T>) {}
   visitBool<T extends arrow.Bool>(vector: arrow.Vector<T>) {
-    const {type, nullBitmap: nullMask} = vector.data;
-    return new Column({type: arrowToCUDFType(type), data: new Uint8Array(vector), nullMask});
+    const {nullBitmap: nullMask} = vector.data;
+    return new Column({type: new Bool8, data: new Uint8Array(vector), nullMask});
   }
-  visitInt8<T extends arrow.Int8>({type, length, data: {values: data, nullBitmap: nullMask}}:
-                                    arrow.Vector<T>) {
-    return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length), nullMask});
+  visitInt8<T extends arrow.Int8>({length,
+                                   data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
+    return new Column({type: new Int8, length, data: data.subarray(0, length), nullMask});
   }
-  visitInt16<T extends arrow.Int16>({type, length, data: {values: data, nullBitmap: nullMask}}:
-                                      arrow.Vector<T>) {
-    return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length), nullMask});
+  visitInt16<T extends arrow.Int16>({length,
+                                     data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
+    return new Column({type: new Int16, length, data: data.subarray(0, length), nullMask});
   }
-  visitInt32<T extends arrow.Int32>({type, length, data: {values: data, nullBitmap: nullMask}}:
-                                      arrow.Vector<T>) {
-    return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length), nullMask});
+  visitInt32<T extends arrow.Int32>({length,
+                                     data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
+    return new Column({type: new Int32, length, data: data.subarray(0, length), nullMask});
   }
-  visitInt64<T extends arrow.Int64>({type, length, data: {values: data, nullBitmap: nullMask}}:
-                                      arrow.Vector<T>) {
-    return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length * 2), nullMask});
+  visitInt64<T extends arrow.Int64>({length,
+                                     data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
+    return new Column({type: new Int64, length, data: data.subarray(0, length * 2), nullMask});
   }
-  visitUint8<T extends arrow.Uint8>({type, length, data: {values: data, nullBitmap: nullMask}}:
-                                      arrow.Vector<T>) {
-    return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length), nullMask});
+  visitUint8<T extends arrow.Uint8>({length,
+                                     data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
+    return new Column({type: new Uint8, length, data: data.subarray(0, length), nullMask});
   }
-  visitUint16<T extends arrow.Uint16>({type, length, data: {values: data, nullBitmap: nullMask}}:
+  visitUint16<T extends arrow.Uint16>({length, data: {values: data, nullBitmap: nullMask}}:
                                         arrow.Vector<T>) {
-    return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length), nullMask});
+    return new Column({type: new Uint16, length, data: data.subarray(0, length), nullMask});
   }
-  visitUint32<T extends arrow.Uint32>({type, length, data: {values: data, nullBitmap: nullMask}}:
+  visitUint32<T extends arrow.Uint32>({length, data: {values: data, nullBitmap: nullMask}}:
                                         arrow.Vector<T>) {
-    return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length), nullMask});
+    return new Column({type: new Uint32, length, data: data.subarray(0, length), nullMask});
   }
-  visitUint64<T extends arrow.Uint64>({type, length, data: {values: data, nullBitmap: nullMask}}:
+  visitUint64<T extends arrow.Uint64>({length, data: {values: data, nullBitmap: nullMask}}:
                                         arrow.Vector<T>) {
-    return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length * 2), nullMask});
+    return new Column({type: new Uint64, length, data: data.subarray(0, length * 2), nullMask});
   }
   // visitFloat16<T extends arrow.Float16>(vector: arrow.Vector<T>) {}
-  visitFloat32<T extends arrow.Float32>({type, length, data: {values: data, nullBitmap: nullMask}}:
+  visitFloat32<T extends arrow.Float32>({length, data: {values: data, nullBitmap: nullMask}}:
                                           arrow.Vector<T>) {
-    return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length), nullMask});
+    return new Column({type: new Float32, length, data: data.subarray(0, length), nullMask});
   }
-  visitFloat64<T extends arrow.Float64>({type, length, data: {values: data, nullBitmap: nullMask}}:
+  visitFloat64<T extends arrow.Float64>({length, data: {values: data, nullBitmap: nullMask}}:
                                           arrow.Vector<T>) {
-    return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length), nullMask});
+    return new Column({type: new Float64, length, data: data.subarray(0, length), nullMask});
   }
-  visitUtf8<T extends arrow.Utf8>(
-    {type, length, data: {values, valueOffsets, nullBitmap: nullMask}}: arrow.Vector<T>) {
+  visitUtf8<T extends arrow.Utf8>({length, data: {values, valueOffsets, nullBitmap: nullMask}}:
+                                    arrow.Vector<T>) {
     return new Column({
       length,
-      type: arrowToCUDFType(type),
+      type: new Utf8String,
       nullMask,
       children: [
         // offsets
@@ -104,35 +115,34 @@ class VectorToColumnVisitor extends arrow.Visitor {
   // visitBinary<T extends arrow.Binary>(vector: arrow.Vector<T>) {}
   // visitFixedSizeBinary<T extends arrow.FixedSizeBinary>(vector: arrow.Vector<T>) {}
   // visitDate<T extends arrow.Date_>(vector: arrow.Vector<T>) {}
-  visitDateDay<T extends arrow.DateDay>({type, length, data: {values: data, nullBitmap: nullMask}}:
+  visitDateDay<T extends arrow.DateDay>({length, data: {values: data, nullBitmap: nullMask}}:
                                           arrow.Vector<T>) {
-    return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length), nullMask});
+    return new Column({type: new TimestampDay, length, data: data.subarray(0, length), nullMask});
   }
   visitDateMillisecond<T extends arrow.DateMillisecond>(
-    {type, length, data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
+    {length, data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
     return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length), nullMask});
+      {type: new TimestampMillisecond, length, data: data.subarray(0, length), nullMask});
   }
   visitTimestampSecond<T extends arrow.TimestampSecond>(
-    {type, length, data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
+    {length, data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
     return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length * 2), nullMask});
+      {type: new TimestampSecond, length, data: data.subarray(0, length * 2), nullMask});
   }
   visitTimestampMillisecond<T extends arrow.TimestampMillisecond>(
-    {type, length, data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
+    {length, data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
     return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length * 2), nullMask});
+      {type: new TimestampMillisecond, length, data: data.subarray(0, length * 2), nullMask});
   }
   visitTimestampMicrosecond<T extends arrow.TimestampMicrosecond>(
-    {type, length, data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
+    {length, data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
     return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length * 2), nullMask});
+      {type: new TimestampMicrosecond, length, data: data.subarray(0, length * 2), nullMask});
   }
   visitTimestampNanosecond<T extends arrow.TimestampNanosecond>(
-    {type, length, data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
+    {length, data: {values: data, nullBitmap: nullMask}}: arrow.Vector<T>) {
     return new Column(
-      {type: arrowToCUDFType(type), length, data: data.subarray(0, length * 2), nullMask});
+      {type: new TimestampNanosecond, length, data: data.subarray(0, length * 2), nullMask});
   }
   // visitTimeSecond<T extends arrow.TimeSecond>(vector: arrow.Vector<T>) {}
   // visitTimeMillisecond<T extends arrow.TimeMillisecond>(vector: arrow.Vector<T>) {}
@@ -141,26 +151,28 @@ class VectorToColumnVisitor extends arrow.Visitor {
   // visitDecimal<T extends arrow.Decimal>(vector: arrow.Vector<T>) {}
   visitList<T extends arrow.List>(vector: arrow.Vector<T>) {
     const {type, length, data: {valueOffsets, nullBitmap: nullMask}} = vector;
+    const offsets =
+      new Column({type: new Int32, length: length + 1, data: valueOffsets.subarray(0, length + 1)});
+    const elements = this.visit(vector.getChildAt(0) as arrow.Vector<T['valueType']>);
     return new Column({
       length,
-      type: arrowToCUDFType(type),
+      type: new List(type.children[0].clone({type: elements.type, nullable: elements.nullable})),
       nullMask,
       children: [
-        // offsets
-        new Column(
-          {type: new Int32, length: length + 1, data: valueOffsets.subarray(0, length + 1)}),
-        // elements
-        this.visit(vector.getChildAt(0) as arrow.Vector<T['valueType']>),
+        offsets,
+        elements,
       ]
     });
   }
   visitStruct<T extends arrow.Struct>(vector: arrow.Vector<T>) {
     const {type, length, data: {nullBitmap: nullMask}} = vector;
+    const children = type.children.map((_, i) => this.visit(vector.getChildAt(i) as arrow.Vector));
     return new Column({
       length,
-      type: arrowToCUDFType(type),
+      type: new Struct(children.map(
+        (child, i) => type.children[i].clone({type: child.type, nullable: child.nullable}))),
       nullMask,
-      children: type.children.map((_, i) => this.visit(vector.getChildAt(i) as arrow.Vector))
+      children,
     });
   }
   // visitDenseUnion<T extends arrow.DenseUnion>(vector: arrow.Vector<T>) {}
@@ -171,7 +183,7 @@ class VectorToColumnVisitor extends arrow.Visitor {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const categories = this.visit(vector.data.dictionary!);
     return new Column(
-      {length, type: arrowToCUDFType(type), nullMask, children: [codes, categories]});
+      {length, type: new Categorical(categories.type), nullMask, children: [codes, categories]});
   }
   // visitIntervalDayTime<T extends arrow.IntervalDayTime>(vector: arrow.Vector<T>) {}
   // visitIntervalYearMonth<T extends arrow.IntervalYearMonth>(vector: arrow.Vector<T>) {}

--- a/modules/cudf/src/column/strings/combine.cpp
+++ b/modules/cudf/src/column/strings/combine.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,11 +19,12 @@
 #include <node_rmm/device_buffer.hpp>
 
 #include <cudf/column/column.hpp>
+#include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/combine.hpp>
+#include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+
 #include <rmm/device_buffer.hpp>
-#include "cudf/scalar/scalar.hpp"
-#include "cudf/table/table_view.hpp"
 
 #include <napi.h>
 

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -25,6 +25,7 @@ import {Join, JoinResult} from './dataframe/join';
 import {DataFrameFormatter, DisplayOptions} from './dataframe/print';
 import {GroupByMultiple, GroupByMultipleProps, GroupBySingle, GroupBySingleProps} from './groupby';
 import {Scalar} from './scalar';
+import {DISPOSER} from './scope';
 import {Series} from './series';
 import {Table, ToArrowMetadata} from './table';
 import {CSVTypeMap, ReadCSVOptions, WriteCSVOptions} from './types/csv';
@@ -180,9 +181,6 @@ export class DataFrame<T extends TypeMap = any> {
 
   declare private _accessor: ColumnAccessor<T>;
 
-  static disposables: {[key: number]: Series|DataFrame} = {};
-  static scopeID: number|null                           = null;
-
   /**
    * Create a new cudf.DataFrame
    *
@@ -203,7 +201,7 @@ export class DataFrame<T extends TypeMap = any> {
   constructor(data: any = {}) {
     this._accessor =
       (data instanceof ColumnAccessor) ? data : new ColumnAccessor(_seriesToColumns(data));
-    if (DataFrame.scopeID != null) { DataFrame.disposables[DataFrame.scopeID] = this; }
+    DISPOSER.add(this);
   }
 
   /**

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -201,7 +201,7 @@ export class DataFrame<T extends TypeMap = any> {
   constructor(data: any = {}) {
     this._accessor =
       (data instanceof ColumnAccessor) ? data : new ColumnAccessor(_seriesToColumns(data));
-    DISPOSER.add(this);
+    DISPOSER.add(this.asTable());
   }
 
   /**

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -180,6 +180,9 @@ export class DataFrame<T extends TypeMap = any> {
 
   declare private _accessor: ColumnAccessor<T>;
 
+  static disposables: {[key: number]: Series|DataFrame} = {};
+  static scopeID: number|null                           = null;
+
   /**
    * Create a new cudf.DataFrame
    *
@@ -200,6 +203,7 @@ export class DataFrame<T extends TypeMap = any> {
   constructor(data: any = {}) {
     this._accessor =
       (data instanceof ColumnAccessor) ? data : new ColumnAccessor(_seriesToColumns(data));
+    if (DataFrame.scopeID != null) { DataFrame.disposables[DataFrame.scopeID] = this; }
   }
 
   /**

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -634,8 +634,8 @@ export class DataFrame<T extends TypeMap = any> {
    * // {a: [null, 4, 3, 2, 1, 0], b: [0, 1, 2, 3, 4, 5]}
    * ```
    */
-  sortValues<R extends keyof T>(options: {[P in R]: OrderSpec}) {
-    return this.gather(this.orderBy(options));
+  sortValues<R extends keyof T>(options: {[P in R]: OrderSpec}, memoryResource?: MemoryResource) {
+    return this.gather(this.orderBy(options), false, memoryResource);
   }
 
   /**

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -278,7 +278,9 @@ export class DataFrame<T extends TypeMap = any> {
   get types() { return this._accessor.types; }
 
   /** @ignore */
-  asTable() { return new Table({columns: this._accessor.columns}); }
+  asTable() {
+    return new Table({columns: this._accessor.columns.filter(({disposed}) => !disposed)});
+  }
 
   /**
    * Return a string with a tabular representation of the DataFrame, pretty-printed according to the

--- a/modules/cudf/src/dataframe/print.ts
+++ b/modules/cudf/src/dataframe/print.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -144,9 +144,9 @@ export class DataFrameFormatter<T extends TypeMap> {
 
     const widths: {[key: string]: number} = {};
     for (const name of [...frame.names]) {
-      const lengths   = frame.get(name).len();
-      const truncated = lengths.scatter(3, inds.gather(lengths.gt(this.maxColWidth)));  // '...'
-      widths[name]    = Math.max(name.length, truncated.max());
+      const lengths   = (frame.get(name) as Series<Utf8String>).len();
+      const truncated = lengths.scatter(3, inds.filter(lengths.gt(this.maxColWidth)));  // '...'
+      widths[name]    = Math.max(name.length, Number(truncated.max()));
     }
     return widths;
   }

--- a/modules/cudf/src/index.ts
+++ b/modules/cudf/src/index.ts
@@ -18,6 +18,7 @@ export * from './column';
 export * from './data_frame';
 export * from './groupby';
 export * from './series';
+export * from './scope';
 export * from './table';
 export * from './types/csv';
 export * from './types/enums';

--- a/modules/cudf/src/node_cudf/column.hpp
+++ b/modules/cudf/src/node_cudf/column.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/reduction.hpp>
 #include <cudf/replace.hpp>
 #include <cudf/stream_compaction.hpp>
 #include <cudf/strings/combine.hpp>
@@ -34,7 +35,6 @@
 #include <cudf/unary.hpp>
 
 #include <rmm/device_buffer.hpp>
-#include "cudf/reduction.hpp"
 
 #include <napi.h>
 
@@ -837,6 +837,7 @@ struct Column : public EnvLocalObjectWrap<Column> {
   void dispose(Napi::CallbackInfo const&);
 
   Napi::Value gather(Napi::CallbackInfo const& info);
+  Napi::Value apply_boolean_mask(Napi::CallbackInfo const& info);
   Napi::Value copy(Napi::CallbackInfo const& info);
 
   Napi::Value get_child(Napi::CallbackInfo const& info);

--- a/modules/cudf/src/node_cudf/column.hpp
+++ b/modules/cudf/src/node_cudf/column.hpp
@@ -829,6 +829,7 @@ struct Column : public EnvLocalObjectWrap<Column> {
   Napi::Value size(Napi::CallbackInfo const& info);
   Napi::Value data(Napi::CallbackInfo const& info);
   Napi::Value null_mask(Napi::CallbackInfo const& info);
+  Napi::Value disposed(Napi::CallbackInfo const& info);
   Napi::Value has_nulls(Napi::CallbackInfo const& info);
   Napi::Value null_count(Napi::CallbackInfo const& info);
   Napi::Value is_nullable(Napi::CallbackInfo const& info);

--- a/modules/cudf/src/node_cudf/table.hpp
+++ b/modules/cudf/src/node_cudf/table.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -240,6 +240,7 @@ struct Table : public EnvLocalObjectWrap<Table> {
   Napi::Value gather(Napi::CallbackInfo const& info);
   Napi::Value scatter_scalar(Napi::CallbackInfo const& info);
   Napi::Value scatter_table(Napi::CallbackInfo const& info);
+  Napi::Value apply_boolean_mask(Napi::CallbackInfo const& info);
   // table/concatenate.cpp
   static Napi::Value concat(Napi::CallbackInfo const& info);
   // table/join.cpp

--- a/modules/cudf/src/scope.ts
+++ b/modules/cudf/src/scope.ts
@@ -38,9 +38,11 @@ export class Disposer {
   exit(result: any) {
     if (this.currentScopeId > -1) {
       this.currentScopeId -= 1;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const test = new Set(this.trackedResources.pop()!.flatMap(flattenColumns));
       const keep = new Set([
         result,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         ...this.ingoredResources.pop()!,
         ...this.ingoredResources.flat(1),
         ...this.trackedResources.flat(1),

--- a/modules/cudf/src/scope.ts
+++ b/modules/cudf/src/scope.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2020-2022, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {DataFrame} from './data_frame';
+import {Series} from './series';
+
+let scopeID = 0;
+
+export function scope<T extends DataFrame|Series, F extends(() => T | Promise<T>)>(cb: F):
+  ReturnType<F> {
+  const resources = [] as (DataFrame<any>| Series<any>)[];
+  const new_id    = scopeID++;
+  const old_id    = DataFrame.scopeID;
+
+  DataFrame.scopeID             = new_id;
+  DataFrame.disposables[new_id] = resources;
+
+  Series.scopeID             = new_id;
+  Series.disposables[new_id] = resources;
+
+  function cleanup(value: any) {
+    for (const resource of resources) {
+      if (resource !== value) { resource.dispose(); }
+    }
+    delete DataFrame.disposables[new_id];
+    delete Series.disposables[new_id];
+  }
+
+  const result = cb();
+
+  DataFrame.scopeID = old_id;
+  Series.scopeID    = old_id;
+
+  if (result instanceof Promise) {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    result.then(cleanup);
+  } else {
+    cleanup(result);
+  }
+
+  return result as any;
+}

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -567,12 +567,8 @@ export class AbstractSeries<T extends DataType = any> {
   }
 
   /** @ignore */
-  public _col: Column<T>;
+  declare public _col: Column<T>;
 
-  protected constructor(input: AbstractSeries<T>|SeriesProps<T>|Column<T>|arrow.Vector<T>) {
-    this._col = asColumn<T>(input);
-    DISPOSER.add(this);
-  }
 
   /**
    * The data type of elements in the underlying data.

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -539,8 +539,12 @@ export class AbstractSeries<T extends DataType = any> {
   /** @ignore */
   public _col: Column<T>;
 
+  static disposables: {[key: number]: Series|DataFrame} = {};
+  static scopeID: number|null                           = null;
+
   protected constructor(input: AbstractSeries<T>|SeriesProps<T>|Column<T>|arrow.Vector<T>) {
     this._col = asColumn<T>(input);
+    if (Series.scopeID != null) { Series.disposables[Series.scopeID] = this; }
   }
 
   /**

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -1638,13 +1638,8 @@ function asColumn<T extends DataType>(value: AbstractSeries<T>|SeriesProps<T>  /
 function asColumn<T extends DataType>(value: any) {
   if (!value) { value = []; }
 
-  // If already a Series, extract the Column
-  if (value instanceof AbstractSeries) { value = value._col; }
-
-  // If Column or ColumnProps, ensure dtype is a concrete instance
-  if (value.type && !(value.type instanceof arrow.DataType)) {
-    value.type = arrowToCUDFType<T>(value.type);
-  }
+  // Return early if it's already a Series
+  if (value instanceof AbstractSeries) { return value._col; }
 
   // Return early if it's already a Column
   if (value instanceof Column) { return value as Column<T>; }

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -1826,8 +1826,8 @@ function _nLargestOrSmallest<T extends DataType>(
 }
 
 function transferFields<T extends DataType>(lhs: T, rhs: T) {
-  const {children: lhsFields} = {} = lhs;
-  const {children: rhsFields} = {} = rhs;
+  const {children: lhsFields} = lhs;
+  const {children: rhsFields} = rhs;
   if (lhsFields && rhsFields && lhsFields.length && rhsFields.length) {
     lhsFields.forEach(({name, type, nullable, metadata}, i) => {
       rhsFields[i] = arrow.Field.new({

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -36,6 +36,7 @@ import {Column} from './column';
 import {fromArrow} from './column/from_arrow';
 import {DataFrame} from './data_frame';
 import {Scalar} from './scalar';
+import {DISPOSER} from './scope';
 import {Table} from './table';
 import {
   Bool8,
@@ -539,12 +540,9 @@ export class AbstractSeries<T extends DataType = any> {
   /** @ignore */
   public _col: Column<T>;
 
-  static disposables: {[key: number]: Series|DataFrame} = {};
-  static scopeID: number|null                           = null;
-
   protected constructor(input: AbstractSeries<T>|SeriesProps<T>|Column<T>|arrow.Vector<T>) {
     this._col = asColumn<T>(input);
-    if (Series.scopeID != null) { Series.disposables[Series.scopeID] = this; }
+    DISPOSER.add(this);
   }
 
   /**

--- a/modules/cudf/src/series/integral.ts
+++ b/modules/cudf/src/series/integral.ts
@@ -232,8 +232,7 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
    * ```
    */
   cumulativeMax(skipNulls = true, memoryResource?: MemoryResource): Series<T> {
-    const col = this._prepare_scan_series(skipNulls);
-    return Series.new(col.cumulativeMax(memoryResource));
+    return this.__construct(this._prepare_scan_series(skipNulls).cumulativeMax(memoryResource));
   }
 
   /**
@@ -254,8 +253,7 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
    * ```
    */
   cumulativeMin(skipNulls = true, memoryResource?: MemoryResource): Series<T> {
-    const col = this._prepare_scan_series(skipNulls);
-    return Series.new(col.cumulativeMin(memoryResource));
+    return this.__construct(this._prepare_scan_series(skipNulls).cumulativeMin(memoryResource));
   }
 
   /**
@@ -276,8 +274,7 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
    * ```
    */
   cumulativeProduct(skipNulls = true, memoryResource?: MemoryResource): Series<T> {
-    const col = this._prepare_scan_series(skipNulls);
-    return Series.new(col.cumulativeProduct(memoryResource));
+    return this.__construct(this._prepare_scan_series(skipNulls).cumulativeProduct(memoryResource));
   }
 
   /**
@@ -298,8 +295,7 @@ abstract class IntSeries<T extends Integral> extends NumericSeries<T> {
    * ```
    */
   cumulativeSum(skipNulls = true, memoryResource?: MemoryResource): Series<T> {
-    const col = this._prepare_scan_series(skipNulls);
-    return Series.new(col.cumulativeSum(memoryResource));
+    return this.__construct(this._prepare_scan_series(skipNulls).cumulativeSum(memoryResource));
   }
 
   /** @inheritdoc */

--- a/modules/cudf/src/series/list.ts
+++ b/modules/cudf/src/series/list.ts
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Field} from 'apache-arrow';
-
-import {Column} from '../column';
 import {Series} from '../series';
 import {DataType, Int32, List} from '../types/dtypes';
 
@@ -83,25 +80,4 @@ export class ListSeries<T extends DataType> extends Series<List<T>> {
     const value = this._col.getValue(index);
     return value === null ? null : Series.new(value);
   }
-
-  /** @ignore */
-  protected __construct(col: Column<List<T>>) {
-    return new ListSeries(Object.assign(col, {type: fixNames(this.type, col.type)}));
-  }
-}
-
-Object.defineProperty(ListSeries.prototype, '__construct', {
-  writable: false,
-  enumerable: false,
-  configurable: true,
-  value: (ListSeries.prototype as any).__construct,
-});
-
-function fixNames<T extends DataType>(lhs: T, rhs: T) {
-  if (lhs.children && rhs.children && lhs.children.length && rhs.children.length) {
-    lhs.children.forEach(({name, type}, idx) => {
-      rhs.children[idx] = Field.new({name, type: fixNames(type, rhs.children[idx].type)});
-    });
-  }
-  return rhs;
 }

--- a/modules/cudf/src/series/string.ts
+++ b/modules/cudf/src/series/string.ts
@@ -306,7 +306,7 @@ export class StringSeries extends Series<Utf8String> {
    */
   pad(width: number, side: PadSideType = 'right', fill_char = ' ', memoryResource?: MemoryResource):
     Series<Utf8String> {
-    return Series.new(this._col.pad(width, side, fill_char, memoryResource));
+    return this.__construct(this._col.pad(width, side, fill_char, memoryResource));
   }
 
   /**
@@ -332,7 +332,7 @@ export class StringSeries extends Series<Utf8String> {
    * ```
    */
   zfill(width: number, memoryResource?: MemoryResource): Series<Utf8String> {
-    return Series.new(this._col.zfill(width, memoryResource));
+    return this.__construct(this._col.zfill(width, memoryResource));
   }
 
   /**
@@ -358,8 +358,8 @@ export class StringSeries extends Series<Utf8String> {
    * [...a.getJSONObject("$.foo").map(JSON.parse)] // object [{ bar: 'baz' }, { baz: 'bar' }]
    * ```
    */
-  getJSONObject(jsonPath: string, memoryResource?: MemoryResource): StringSeries {
-    return Series.new(this._col.getJSONObject(jsonPath, memoryResource));
+  getJSONObject(jsonPath: string, memoryResource?: MemoryResource): Series<Utf8String> {
+    return this.__construct(this._col.getJSONObject(jsonPath, memoryResource));
   }
 
   /**

--- a/modules/cudf/src/series/struct.ts
+++ b/modules/cudf/src/series/struct.ts
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Field} from 'apache-arrow';
-
-import {Column} from '../column';
 import {Series} from '../series';
-import {DataType, Struct} from '../types/dtypes';
+import {Struct} from '../types/dtypes';
 import {TypeMap} from '../types/mappings';
 
 /**
@@ -78,25 +75,4 @@ export class StructSeries<T extends TypeMap> extends Series<Struct<T>> {
              : this.type.children.reduce(
                  (xs, f, i) => ({...xs, [f.name]: value.getColumnByIndex(i).getValue(0)}), {});
   }
-
-  /** @ignore */
-  protected __construct(col: Column<Struct<T>>) {
-    return new StructSeries(Object.assign(col, {type: fixNames(this.type, col.type)}));
-  }
-}
-
-Object.defineProperty(StructSeries.prototype, '__construct', {
-  writable: false,
-  enumerable: false,
-  configurable: true,
-  value: (StructSeries.prototype as any).__construct,
-});
-
-function fixNames<T extends DataType>(lhs: T, rhs: T) {
-  if (lhs.children && rhs.children && lhs.children.length && rhs.children.length) {
-    lhs.children.forEach(({name, type}, idx) => {
-      rhs.children[idx] = Field.new({name, type: fixNames(type, rhs.children[idx].type)});
-    });
-  }
-  return rhs;
 }

--- a/modules/cudf/src/table.cpp
+++ b/modules/cudf/src/table.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ Napi::Function Table::Init(Napi::Env const& env, Napi::Object exports) {
                        InstanceMethod<&Table::scatter_scalar>("scatterScalar"),
                        InstanceMethod<&Table::scatter_table>("scatterTable"),
                        InstanceMethod<&Table::gather>("gather"),
+                       InstanceMethod<&Table::apply_boolean_mask>("applyBooleanMask"),
                        InstanceMethod<&Table::get_column>("getColumnByIndex"),
                        InstanceMethod<&Table::to_arrow>("toArrow"),
                        InstanceMethod<&Table::order_by>("orderBy"),

--- a/modules/cudf/src/table.ts
+++ b/modules/cudf/src/table.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -150,11 +150,36 @@ export interface Table {
   dispose(): void;
 
   /**
+   * @summary Return sub-selection from a Table.
+   *
+   * @description Gathers the rows of the source columns according to `selection`, such that row "i"
+   * in the resulting Table's columns will contain row `selection[i]` from the source columns. The
+   * number of rows in the result table will be equal to the number of elements in selection. A
+   * negative value i in the selection is interpreted as i+n, where `n` is the number of rows in
+   * the source table.
+   *
+   * For dictionary columns, the keys column component is copied and not trimmed if the gather
+   * results in abandoned key elements.
+   *
+   * @param selection A Series of 8/16/32-bit signed or unsigned integer indices to gather.
+   * @param nullify_out_of_bounds If `true`, coerce rows that corresponds to out-of-bounds indices
+   *   in the selection to null. If `false`, skips all bounds checking for selection values. Pass
+   *   false if you are certain that the selection contains only valid indices for better
+   *   performance. If `false` and there are out-of-bounds indices in the selection, the behavior
+   *   is undefined. Defaults to `false`.
+   * @param memoryResource An optional MemoryResource used to allocate the result's device memory.
+   */
+  gather(selection: Column<IndexType>,
+         nullify_out_of_bounds: boolean,
+         memoryResource?: MemoryResource): Table;
+
+  /**
    * Return sub-selection from a Table
    *
-   * @param selection
+   * @param selection A Series of 8/16/32-bit signed or unsigned integer indices.
+   * @param memoryResource An optional MemoryResource used to allocate the result's device memory.
    */
-  gather(selection: Column<IndexType|Bool8>, nullify_out_of_bounds?: boolean): Table;
+  applyBooleanMask(selection: Column<Bool8>, memoryResource?: MemoryResource): Table;
 
   /**
    * Scatters row of values into this Table according to provided indices.

--- a/modules/cudf/src/table/stream_compaction.cpp
+++ b/modules/cudf/src/table/stream_compaction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
 #include <node_cudf/column.hpp>
 #include <node_cudf/table.hpp>
 #include <node_cudf/utilities/napi_to_cpp.hpp>
+
 #include <nv_node/utilities/args.hpp>
 #include <nv_node/utilities/napi_to_cpp.hpp>
 
-#include "cudf/types.hpp"
-
 #include <cudf/stream_compaction.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/types.hpp>
 
 #include <memory>
 #include <vector>

--- a/modules/cudf/src/utilities/dtypes.cpp
+++ b/modules/cudf/src/utilities/dtypes.cpp
@@ -240,23 +240,21 @@ Napi::Object cudf_to_arrow_type(Napi::Env const& env, cudf::data_type const& cud
 
 Napi::Object column_to_arrow_type(Napi::Env const& env,
                                   cudf::data_type const& cudf_type,
-                                  Napi::Array children_value) {
-  auto arrow_type                         = Napi::Object::New(env);
-  std::vector<Column::wrapper_t> children = NapiToCPP{children_value};
+                                  Napi::Array children) {
+  auto arrow_type = Napi::Object::New(env);
   switch (cudf_type.id()) {
     case cudf::type_id::DICTIONARY32: {
       arrow_type.Set("typeId", -1);
-      arrow_type.Set("indices", cudf_to_arrow_type(env, children[0]->type()));
-      arrow_type.Set("dictionary", cudf_to_arrow_type(env, children[1]->type()));
+      arrow_type.Set("indices", children.Get(0u).ToObject().Get("type"));
+      arrow_type.Set("dictionary", children.Get(1).ToObject().Get("type"));
       arrow_type.Set("isOrdered", false);
       break;
     }
     case cudf::type_id::LIST: {
       auto list_children = Napi::Array::New(env, 1);
-      if (children.size() > 1) {
-        auto field              = Napi::Object::New(env);
-        Column::wrapper_t child = children[1];
-        field.Set("type", column_to_arrow_type(env, child->type(), child->children()));
+      if (children.Length() > 1) {
+        auto field = Napi::Object::New(env);
+        field.Set("type", children.Get(1).ToObject().Get("type"));
         list_children.Set(0u, field);
       }
       arrow_type.Set("typeId", 12);
@@ -264,12 +262,11 @@ Napi::Object column_to_arrow_type(Napi::Env const& env,
       break;
     }
     case cudf::type_id::STRUCT: {
-      auto struct_children = Napi::Array::New(env, children.size());
-      for (unsigned int i = 0; i < children.size(); ++i) {
+      auto struct_children = Napi::Array::New(env, children.Length());
+      for (uint32_t i = 0; i < children.Length(); ++i) {
         Napi::HandleScope scope{env};
-        auto field                = Napi::Object::New(env);
-        Column::wrapper_t child_i = children[i];
-        field.Set("type", column_to_arrow_type(env, child_i->type(), child_i->children()));
+        auto field = Napi::Object::New(env);
+        field.Set("type", children.Get(i).ToObject().Get("type"));
         struct_children.Set(i, field);
       }
       arrow_type.Set("typeId", 13);

--- a/modules/cudf/test/cudf-scope-test.ts
+++ b/modules/cudf/test/cudf-scope-test.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2020-2022, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {DataFrame, scope, Series} from '@rapidsai/cudf';
+
+test('basic disposes', () => {
+  let test: any = null;
+
+  const result = scope(() => {
+    test = Series.sequence({size: 20});
+    return Series.sequence({size: 30});
+  });
+
+  expect(test._col.disposed).toBe(true);
+  expect(result._col.disposed).toBe(false);
+});
+
+test('basic disposes promise', async () => {
+  let test: any = null;
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  const promise = scope(async () => {
+    test = Series.sequence({size: 20});
+    return Series.sequence({size: 30});
+  });
+
+  const resolver = async () => promise;
+  const result              = await resolver();
+
+  expect(test._col.disposed).toBe(true);
+  expect(result._col.disposed).toBe(false);
+});
+
+test('explicit keep', () => {
+  let test: any = null;
+  const outer   = Series.sequence({size: 30});
+
+  const result = scope(() => {
+    test        = Series.sequence({size: 20});
+    const inner = Series.sequence({size: 30});
+    return new DataFrame({
+      outer: outer,
+      inner: inner,
+    });
+  }, [outer]);
+
+  expect(test._col.disposed).toBe(true);
+  expect(result.get('inner')._col.disposed).toBe(false);
+  expect(result.get('outer')._col.disposed).toBe(false);
+});
+
+test('nested disposes', () => {
+  const outer          = Series.sequence({size: 30});
+  let test_inner: any  = null;
+  let test_middle: any = null;
+
+  const result = scope(() => {
+    const middle = Series.sequence({size: 30});
+    test_middle  = Series.sequence({size: 20});
+
+    const result = scope(() => {
+      test_inner  = Series.sequence({size: 20});
+      const inner = Series.sequence({size: 30});
+      return new DataFrame({
+        inner: inner,
+      });
+    });
+
+    expect(test_inner._col.disposed).toBe(true);
+    expect(test_middle._col.disposed).toBe(false);
+    expect(result.get('inner')._col.disposed).toBe(false);
+    expect(middle._col.disposed).toBe(false);
+    return result.assign({middle: middle});
+  });
+
+  expect(test_inner._col.disposed).toBe(true);
+  expect(test_middle._col.disposed).toBe(true);
+  expect(result.get('middle')._col.disposed).toBe(false);
+  expect(result.get('inner')._col.disposed).toBe(false);
+  expect(outer._col.disposed).toBe(false);
+});

--- a/modules/cudf/test/cudf-table-tests.ts
+++ b/modules/cudf/test/cudf-table-tests.ts
@@ -61,7 +61,7 @@ test('Table.gather (bad argument)', () => {
 
   const selection = [2, 4, 5];
 
-  expect(() => table_0.gather(<any>selection)).toThrow();
+  expect(() => table_0.gather(<any>selection, false)).toThrow();
 });
 
 test('Table.gather (indices)', () => {
@@ -72,7 +72,7 @@ test('Table.gather (indices)', () => {
 
   const selection = new Column({type: new Int32, data: new Int32Buffer([2, 4, 5])});
 
-  const result = table_0.gather(selection);
+  const result = table_0.gather(selection, false);
   expect(result.numRows).toBe(3);
 
   const r0 = result.getColumnByIndex(0);
@@ -91,7 +91,7 @@ test('Table.gather (indices)', () => {
   expect(r1.getValue(2)).toBe(5.0);
 });
 
-test('Table.gather (bitmask)', () => {
+test('Table.applyBooleanMask', () => {
   const col_0 = new Column({type: new Int32, data: new Int32Buffer([0, 1, 2, 3, 4, 5])});
   const col_1 =
     new Column({type: new Float32, data: new Float32Buffer([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])});
@@ -103,7 +103,7 @@ test('Table.gather (bitmask)', () => {
     data: new Uint8Buffer([0, 0, 1, 0, 1, 1]),
   });
 
-  const result = table_0.gather(selection);
+  const result = table_0.applyBooleanMask(selection);
   expect(result.numRows).toBe(3);
 
   const r0 = result.getColumnByIndex(0);

--- a/modules/cudf/test/series/categorical-tests.ts
+++ b/modules/cudf/test/series/categorical-tests.ts
@@ -41,8 +41,8 @@ describe('CategoricalSeries', () => {
     const categories  = Series.new(['foo', 'foo', 'bar', 'bar']);
     const categorical = categories.cast(new Categorical(categories.type));
     expect([...categorical]).toEqual(['foo', 'foo', 'bar', 'bar']);
-    expect([...categorical.codes]).toEqual([1, 1, 0, 0]);
-    expect([...categorical.categories]).toEqual(['bar', 'foo']);
+    expect([...categorical.codes]).toEqual([0, 0, 1, 1]);
+    expect([...categorical.categories]).toEqual(['foo', 'bar']);
   });
 
   test('Can cast an Integral Series to Categorical', () => {
@@ -51,5 +51,14 @@ describe('CategoricalSeries', () => {
     expect([...categorical]).toEqual(['0', '1', '2', '1', '1', '3']);
     expect([...categorical.codes]).toEqual([0, 1, 2, 1, 1, 3]);
     expect([...categorical.categories]).toEqual(['0', '1', '2', '3']);
+  });
+
+  test('Can set new categories', () => {
+    const categories = Series.new(['foo', 'foo', 'bar', 'bar']);
+    const lhs        = categories.cast(new Categorical(categories.type));
+    const rhs        = lhs.setCategories(Series.new(['bar', 'foo']));
+    expect([...rhs]).toEqual(['foo', 'foo', 'bar', 'bar']);
+    expect([...rhs.codes]).toEqual([1, 1, 0, 0]);
+    expect([...rhs.categories]).toEqual(['bar', 'foo']);
   });
 });

--- a/modules/cugraph/src/hypergraph.ts
+++ b/modules/cugraph/src/hypergraph.ts
@@ -391,7 +391,7 @@ function create_graph(edges: DataFrame, source: string, target: string): GraphCO
 function _prepend_str(series: Series, val: string, delim: string) {
   const prefix = val + delim;
   const suffix = series.cast(new Categorical(new Utf8String));
-  const codes  = Series.new(suffix.codes);
+  const codes  = suffix.codes;
   const categories =
     Series.new(suffix.categories.replaceNulls('null')._col.replaceSlice(prefix, 0, 0));
 
@@ -399,6 +399,5 @@ function _prepend_str(series: Series, val: string, delim: string) {
 }
 
 function _scalar_init(val: string, size: number): Series<Utf8String> {
-  const indices = Series.sequence({init: 0, size: size, step: 0, type: new Int32});
-  return Series.new([val]).gather(indices);
+  return Series.new([val]).gather(Series.sequence({size, step: 0}), false);
 }

--- a/modules/cugraph/src/renumber.ts
+++ b/modules/cugraph/src/renumber.ts
@@ -27,19 +27,19 @@ export function renumberNodes<TSource extends DataType, TTarget extends DataType
     return new DataFrame<{id: Int32, node: CommonType<TSource, TTarget>}>(
              {id: node.encodeLabels(undefined, new Int32), node: node as any})
       .sortValues({id: {ascending: true}});
-  });
+  }, [src, dst]);
 }
 
 export function renumberEdges<TSource extends DataType, TTarget extends DataType>(
   src: Series<TSource>, dst: Series<TTarget>, nodes: Nodes<TSource, TTarget>) {
   return scope(() => {
-    const idx   = Series.sequence({type: new Int32, size: src.length, init: 0});
+    const idx   = Series.sequence({size: src.length});
     const edges = new DataFrame<{src: TSource, dst: TTarget, idx: Int32}>(
       {src: src as any, dst: dst as any, idx});
     return renumberTargets(renumberSources(edges, nodes), nodes)
       .sortValues({idx: {ascending: true}})
       .drop(['idx']);
-  });
+  }, [src, dst]);
 }
 
 function renumberSources<TSource extends DataType, TTarget extends DataType>(
@@ -49,7 +49,7 @@ function renumberSources<TSource extends DataType, TTarget extends DataType>(
                   .join({other: nodes, on: ['node']})
                   .sortValues({idx: {ascending: true}});
     return edges.assign({src: tmp.get('id')}) as DataFrame<{src: Int32, dst: TTarget, idx: Int32}>;
-  });
+  }, [edges, nodes]);
 }
 
 function renumberTargets<TSource extends DataType, TTarget extends DataType>(
@@ -59,5 +59,5 @@ function renumberTargets<TSource extends DataType, TTarget extends DataType>(
                   .join({other: nodes, on: ['node']})
                   .sortValues({idx: {ascending: true}});
     return edges.assign({dst: tmp.get('id')}) as DataFrame<{src: Int32, dst: Int32, idx: Int32}>;
-  });
+  }, [edges, nodes]);
 }

--- a/modules/cugraph/src/renumber.ts
+++ b/modules/cugraph/src/renumber.ts
@@ -36,7 +36,7 @@ export function renumberEdges<TSource extends DataType, TTarget extends DataType
     const idx   = Series.sequence({type: new Int32, size: src.length, init: 0});
     const edges = new DataFrame<{src: TSource, dst: TTarget, idx: Int32}>(
       {src: src as any, dst: dst as any, idx});
-    return renumberTargets(renumberSources(edges, nodes), nodes)  //
+    return renumberTargets(renumberSources(edges, nodes), nodes)
       .sortValues({idx: {ascending: true}})
       .drop(['idx']);
   });

--- a/modules/cugraph/src/renumber.ts
+++ b/modules/cugraph/src/renumber.ts
@@ -12,13 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  CommonType,
-  DataFrame,
-  DataType,
-  Int32,
-  Series,
-} from '@rapidsai/cudf';
+import {CommonType, DataFrame, DataType, Int32, scope, Series} from '@rapidsai/cudf';
 
 type Nodes<TSource extends DataType, TTarget extends DataType> =
   DataFrame<{id: Int32, node: CommonType<TSource, TTarget>}>;
@@ -28,54 +22,42 @@ type Edges<TSource extends DataType, TTarget extends DataType> =
 
 export function renumberNodes<TSource extends DataType, TTarget extends DataType>(
   src: Series<TSource>, dst: Series<TTarget>) {
-  const tmp1 = src.concat(dst);
-  const node = tmp1.unique();
-  tmp1.dispose();
-
-  const tmp2 = new DataFrame<{id: Int32, node: CommonType<TSource, TTarget>}>(
-    {id: node.encodeLabels(undefined, new Int32), node: node as any});
-  const tmp3 = tmp2.sortValues({id: {ascending: true}});
-  tmp2.dispose();
-
-  return tmp3;
+  return scope(() => {
+    const node = src.concat(dst).unique();
+    return new DataFrame<{id: Int32, node: CommonType<TSource, TTarget>}>(
+             {id: node.encodeLabels(undefined, new Int32), node: node as any})
+      .sortValues({id: {ascending: true}});
+  });
 }
 
 export function renumberEdges<TSource extends DataType, TTarget extends DataType>(
   src: Series<TSource>, dst: Series<TTarget>, nodes: Nodes<TSource, TTarget>) {
-  const idx   = Series.sequence({type: new Int32, size: src.length, init: 0});
-  const edges = new DataFrame<{src: TSource, dst: TTarget, idx: Int32}>(
-    {src: src as any, dst: dst as any, idx});
-  const tmp = renumberTargets(renumberSources(edges, nodes), nodes)  //
-                .sortValues({idx: {ascending: true}})
-                .drop(['idx']);
-  idx.dispose();
-  return tmp;
+  return scope(() => {
+    const idx   = Series.sequence({type: new Int32, size: src.length, init: 0});
+    const edges = new DataFrame<{src: TSource, dst: TTarget, idx: Int32}>(
+      {src: src as any, dst: dst as any, idx});
+    return renumberTargets(renumberSources(edges, nodes), nodes)  //
+      .sortValues({idx: {ascending: true}})
+      .drop(['idx']);
+  });
 }
 
 function renumberSources<TSource extends DataType, TTarget extends DataType>(
   edges: Edges<TSource, TTarget>, nodes: Nodes<TSource, TTarget>) {
-  const tmp1 = edges.assign<{node: TSource}>({node: edges.get('src')} as any)
-                 .join({other: nodes, on: ['node']});
-  const tmp2 = tmp1.sortValues({idx: {ascending: true}});
-  tmp1.dispose();
-
-  const tmp3 =
-    edges.assign({src: tmp2.get('id')}) as DataFrame<{src: Int32, dst: TTarget, idx: Int32}>;
-  tmp2.drop(['id']).dispose();
-
-  return tmp3;
+  return scope(() => {
+    const tmp = edges.assign<{node: TSource}>({node: edges.get('src')} as any)
+                  .join({other: nodes, on: ['node']})
+                  .sortValues({idx: {ascending: true}});
+    return edges.assign({src: tmp.get('id')}) as DataFrame<{src: Int32, dst: TTarget, idx: Int32}>;
+  });
 }
 
 function renumberTargets<TSource extends DataType, TTarget extends DataType>(
   edges: Edges<Int32, TTarget>, nodes: Nodes<TSource, TTarget>) {
-  const tmp1 = edges.assign<{node: TTarget}>({node: edges.get('dst')} as any)
-                 .join({other: nodes, on: ['node']});
-  const tmp2 = tmp1.sortValues({idx: {ascending: true}});
-  tmp1.dispose();
-
-  const tmp3 =
-    edges.assign({dst: tmp2.get('id')}) as DataFrame<{src: Int32, dst: Int32, idx: Int32}>;
-  tmp2.drop(['id']).dispose();
-
-  return tmp3;
+  return scope(() => {
+    const tmp = edges.assign<{node: TTarget}>({node: edges.get('dst')} as any)
+                  .join({other: nodes, on: ['node']})
+                  .sortValues({idx: {ascending: true}});
+    return edges.assign({dst: tmp.get('id')}) as DataFrame<{src: Int32, dst: Int32, idx: Int32}>;
+  });
 }

--- a/modules/cuml/src/utilities/array_utils.ts
+++ b/modules/cuml/src/utilities/array_utils.ts
@@ -40,12 +40,12 @@ export function seriesToDataFrame<T extends Numeric>(
   input: Series<T>, nComponents: number): DataFrame<{[P in number]: T}> {
   const nSamples = Math.floor(input.length / nComponents);
   let result     = new DataFrame<{[P in number]: T}>({});
-  return scope(() => {
-    for (let i = 0; i < nComponents; i++) {
+  for (let i = 0; i < nComponents; i++) {
+    result = scope(() => {
       const indices =
         Series.sequence({type: new Int32, init: i, size: nSamples, step: nComponents});
-      result = result.assign(new DataFrame({[i]: input.gather(indices)}));
-    }
-    return result;
-  }, [result]);
+      return result.assign(new DataFrame({[i]: input.gather(indices)}));
+    }, [result]);
+  }
+  return result;
 }

--- a/modules/cuspatial/src/quadtree.ts
+++ b/modules/cuspatial/src/quadtree.ts
@@ -230,18 +230,18 @@ export class Quadtree<T extends FloatingPoint> {
   /**
    * @summary Point x-coordinates in the sorted order they appear in the Quadtree.
    */
-  public get pointX(): Series<T> { return Series.new(this._x.gather(this._keyMap)); }
+  public get pointX(): Series<T> { return Series.new(this._x.gather(this._keyMap, false)); }
 
   /**
    * @summary Point y-coordinates in the sorted order they appear in the Quadtree.
    */
-  public get pointY(): Series<T> { return Series.new(this._y.gather(this._keyMap)); }
+  public get pointY(): Series<T> { return Series.new(this._y.gather(this._keyMap, false)); }
 
   /**
    * @summary Point x and y-coordinates in the sorted order they appear in the Quadtree.
    */
   public get points() {
-    const remap = new Table({columns: [this._x, this._y]}).gather(this._keyMap);
+    const remap = new Table({columns: [this._x, this._y]}).gather(this._keyMap, false);
     return new DataFrame({
       x: remap.getColumnByIndex<T>(0),
       y: remap.getColumnByIndex<T>(1),

--- a/modules/demo/sql/sql-cluster-server/index.js
+++ b/modules/demo/sql/sql-cluster-server/index.js
@@ -16,7 +16,7 @@
 
 const {performance}             = require('perf_hooks');
 const {SQLCluster}              = require('@rapidsai/sql');
-const {DataFrame}               = require('@rapidsai/cudf');
+const {DataFrame, scope}        = require('@rapidsai/cudf');
 const {RecordBatchStreamWriter} = require('apache-arrow');
 const fs                        = require('fs');
 
@@ -56,23 +56,22 @@ fastify.register((require('fastify-arrow')))
     fastify.next('/');
     fastify.post('/run_query', async function(request, reply) {
       try {
-        request.log.info({query: request.body}, `calling sqlCluster.sql()`);
-        const t0        = performance.now();
-        const dfs       = await sqlCluster.sql(request.body).catch((err) => {
-          request.log.error({err}, `Error calling sqlCluster.sql`);
-          return new DataFrame();
+        scope(async () => {
+          request.log.info({query: request.body}, `calling sqlCluster.sql()`);
+          const t0        = performance.now();
+          const dfs       = await sqlCluster.sql(request.body).catch((err) => {
+            request.log.error({err}, `Error calling sqlCluster.sql`);
+            return new DataFrame();
+          });
+          const t1        = performance.now();
+          const queryTime = t1 - t0;
+
+          const {results, resultCount} = head(dfs, 500);
+          const arrowTable             = results.toArrow();
+          arrowTable.schema.metadata.set('queryTime', queryTime);
+          arrowTable.schema.metadata.set('queryResults', resultCount);
+          RecordBatchStreamWriter.writeAll(arrowTable).pipe(reply.stream());
         });
-        const t1        = performance.now();
-        const queryTime = t1 - t0;
-
-        const {results, resultCount} = head(dfs, 500);
-        const arrowTable             = results.toArrow();
-        arrowTable.schema.metadata.set('queryTime', queryTime);
-        arrowTable.schema.metadata.set('queryResults', resultCount);
-        RecordBatchStreamWriter.writeAll(arrowTable).pipe(reply.stream());
-
-        results.dispose();
-        dfs.forEach((df) => df.dispose());
       } catch (err) {
         request.log.error({err}, '/run_query error');
         reply.code(500).send(err);
@@ -94,7 +93,7 @@ function head(dfs, rows) {
     rowCount += dfs[i].numRows;
     if (result.numRows <= rows) {
       const head = dfs[i].head(rows - result.numRows);
-      result = result.concat(head);
+      result     = result.concat(head);
       head.dispose();
     }
   }


### PR DESCRIPTION
This PR adds a `scope()` function that can be used to enclose blocks of code that will return a new `Series` or `DataFrame`. All other `Series` or `DataFrame` objects created in the scope will automatically have their `dispose` methods called after. 

cc @trxcllnt tracing this code, it seems to be behaving exactly as expected/intended: a non-disposed result is returned, and all other objects in `resources` were disposed. But now tests e.g. `renumber-test.ts` are failing. Is there some subtlety of applying this that I am missing? E.g. before there was `tmp.drop(['id'])` to suppress disposal, but that is not really an option now. Could that be significant?