### PR TITLE
[FEA] Add more DataFrame and Series convenience functions

### DIFF
--- a/docker-compose.devel.yml
+++ b/docker-compose.devel.yml
@@ -74,7 +74,7 @@ services:
       <<: *base_build_settings
       dockerfile: dev/dockerfiles/devel/package.Dockerfile
       args:
-        CUDAARCHS: "${CUDAARCHS:-NATIVE}"
+        CUDAARCHS: "${CUDAARCHS:-ALL}"
         PARALLEL_LEVEL: "${PARALLEL_LEVEL:-4}"
         RAPIDS_VERSION: "${RAPIDS_VERSION:-22.02.00}"
         SCCACHE_REGION: "${SCCACHE_REGION:-us-west-2}"

--- a/modules/cuda/.vscode/launch.json
+++ b/modules/cuda/.vscode/launch.json
@@ -20,6 +20,7 @@
             "request": "launch",
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
             "skipFiles": [
                 "<node_internals>/**",

--- a/modules/cudf/.vscode/launch.json
+++ b/modules/cudf/.vscode/launch.json
@@ -20,6 +20,7 @@
             "request": "launch",
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
             "skipFiles": [
                 "<node_internals>/**",

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -371,6 +371,31 @@ export class DataFrame<T extends TypeMap = any> {
   }
 
   /**
+   * Return a new DataFrame with specified columns renamed.
+   *
+   * @param nameMap Object mapping old to new Column names.
+   *
+   * @example
+   * ```typescript
+   * import {DataFrame, Series, Int32, Float32}  from '@rapidsai/cudf';
+   * const df = new DataFrame({
+   *  a: Series.new({type: new Int32, data: [0, 1, 1, 2, 2, 2]}),
+   *  b: Series.new({type: new Float32, data: [0, 1, 2, 3, 4, 4]})
+   * });
+   *
+   * df.rename({a: 'c'}) // returns df {b: [0, 1, 2, 3, 4, 4], c: [0, 1, 1, 2, 2, 2]}
+   * ```
+   */
+  rename<U extends string|number, P extends {[K in keyof T]?: U}>(nameMap: P) {
+    const names = Object.keys(nameMap) as (string & keyof P)[];
+    return this.drop(names).assign(names.reduce(
+      (xs, x) =>                                                                  //
+      ({...xs, [`${nameMap[x]!}`]: this.get(x)}),                                 //
+      {} as SeriesMap<{[K in keyof P as `${NonNullable<P[K]>}`]: T[string & K]}>  //
+      ));
+  }
+
+  /**
    * Return whether the DataFrame has a Series.
    *
    * @param name Name of the Series to return.

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -384,11 +384,10 @@ export class DataFrame<T extends TypeMap = any> {
    */
   rename<U extends string|number, P extends {[K in keyof T]?: U}>(nameMap: P) {
     const names = Object.keys(nameMap) as (string & keyof P)[];
-    return this.drop(names).assign(names.reduce(
-      (xs, x) =>                                                                  //
-      ({...xs, [`${nameMap[x]!}`]: this.get(x)}),                                 //
-      {} as SeriesMap<{[K in keyof P as `${NonNullable<P[K]>}`]: T[string & K]}>  //
-      ));
+    return this.drop(names).assign(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      names.reduce((xs, x) => ({...xs, [`${nameMap[x]!}`]: this.get(x)}),
+                   {} as SeriesMap<{[K in keyof P as `${NonNullable<P[K]>}`]: T[string & K]}>));
   }
 
   /**

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -283,12 +283,8 @@ export class DataFrame<T extends TypeMap = any> {
    * options given.
    *
    * @param options
-   * @returns void
    */
-  toString(options: DisplayOptions = {}): string {
-    const formatter = new DataFrameFormatter(options, this);
-    return formatter.render();
-  }
+  toString(options: DisplayOptions = {}) { return new DataFrameFormatter(options, this).render(); }
 
   /**
    * Return a new DataFrame containing only specified columns.

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -561,8 +561,8 @@ export class AbstractSeries<T extends DataType = any> {
     memoryResource?: MemoryResource;
   }): Series<U> {
     const type = opts.type ?? new Int32;
-    const init = type.scalar(opts.init ?? 0) as Scalar<U>;
-    const step = type.scalar(opts.step ?? 1) as Scalar<U>;
+    const init = new Scalar({type, value: <any>opts.init ?? 0}) as Scalar<U>;
+    const step = new Scalar({type, value: <any>opts.step ?? 1}) as Scalar<U>;
     return Series.new(Column.sequence<U>(opts.size, init, step, opts.memoryResource));
   }
 

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -1156,6 +1156,12 @@ export class AbstractSeries<T extends DataType = any> {
   }
 
   /**
+   * Copy the underlying device memory to host and return an Array (or TypedArray) of the values.
+   * @returns
+   */
+  toArray() { return this.toArrow().toArray(); }
+
+  /**
    * Return a string with a tabular representation of the Series, pretty-printed according to the
    * options given.
    *

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -172,8 +172,8 @@ export type Series<T extends arrow.DataType = any> = {
   [arrow.Type.Interval]: never,           // TODO
   [arrow.Type.IntervalDayTime]: never,    // TODO
   [arrow.Type.IntervalYearMonth]: never,  // TODO
-  [arrow.Type.List]: ListSeries<(T extends List ? T['childType'] : any)>,
-  [arrow.Type.Struct]: StructSeries<(T extends Struct ? T['childTypes'] : any)>,
+  [arrow.Type.List]: ListSeries<(T extends List ? T['valueType'] : any)>,
+  [arrow.Type.Struct]: StructSeries<(T extends Struct ? T['dataTypes'] : any)>,
   [arrow.Type.Union]: never,            // TODO
   [arrow.Type.DenseUnion]: never,       // TODO
   [arrow.Type.SparseUnion]: never,      // TODO

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -1093,17 +1093,16 @@ export class AbstractSeries<T extends DataType = any> {
           indices: Series<Int32>|number[],
           check_bounds = false,
           memoryResource?: MemoryResource): Series<T> {
-    const dst  = new Table({columns: [this._col]});
-    const inds = indices instanceof Series ? indices : new Series({type: new Int32, data: indices});
+    const dst = new Table({columns: [this._col]});
+    const idx = Series.new(indices).cast(new Int32)._col;
     if (source instanceof Series) {
-      const src = new Table({columns: [source._col]});
-      const out = dst.scatterTable(src, inds._col, check_bounds, memoryResource);
-      return Series.new(out.getColumnByIndex(0));
-    } else {
-      const src = [new Scalar({type: this.type, value: source})];
-      const out = dst.scatterScalar(src, inds._col, check_bounds, memoryResource);
-      return Series.new(out.getColumnByIndex(0));
+      const src = new Table({columns: [source.cast(this.type)._col]});
+      return Series.new(
+        dst.scatterTable(src, idx, check_bounds, memoryResource).getColumnByIndex(0));
     }
+    const src = [new Scalar({type: this.type, value: source})];
+    return Series.new(
+      dst.scatterScalar(src, idx, check_bounds, memoryResource).getColumnByIndex(0));
   }
 
   /**

--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -35,6 +35,7 @@ import {compareTypes} from 'apache-arrow/visitor/typecomparator';
 import {Column} from './column';
 import {fromArrow} from './column/from_arrow';
 import {DataFrame} from './data_frame';
+import {DisplayOptions} from './dataframe/print';
 import {Scalar} from './scalar';
 import {Table} from './table';
 import {
@@ -1152,6 +1153,16 @@ export class AbstractSeries<T extends DataType = any> {
    */
   [Symbol.iterator](): IterableIterator<T['TValue']|null> {
     return this.toArrow()[Symbol.iterator]() as IterableIterator<T['TValue']|null>;
+  }
+
+  /**
+   * Return a string with a tabular representation of the Series, pretty-printed according to the
+   * options given.
+   *
+   * @param options
+   */
+  toString(options: DisplayOptions&{name?: string} = {}) {
+    return new DataFrame({[options.name ?? '0']: this}).toString(options);
   }
 
   /**

--- a/modules/cudf/src/series/categorical.ts
+++ b/modules/cudf/src/series/categorical.ts
@@ -51,8 +51,8 @@ export class CategoricalSeries<T extends DataType> extends Series<Categorical<T>
   /**
    * @inheritdoc
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public encodeLabels<R extends Integral = Uint32>(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _categories: Series<Categorical<T>> = this,
     type: R                             = new Uint32 as R,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/modules/cudf/src/series/struct.ts
+++ b/modules/cudf/src/series/struct.ts
@@ -52,6 +52,33 @@ export class StructSeries<T extends TypeMap> extends Series<Struct<T>> {
       this._col.getChild<T[P]>(this.type.children.findIndex((f) => f.name === name)));
   }
 
+  /**
+   * Return a value at the specified index to host memory
+   *
+   * @param index the index in this Series to return a value for
+   *
+   * @example
+   * ```typescript
+   * import {Series} from "@rapidsai/cudf";
+   *
+   * // Series<List<Float64>>
+   * Series.new([[1, 2], [3]]).getValue(0) // Series([1, 2])
+   *
+   * // Series<List<Utf8String>>
+   * Series.new([["foo", "bar"], ["test"]]).getValue(1) // Series(["test"])
+   *
+   * // Series<List<Bool8>>
+   * Series.new([[false, true], [true]]).getValue(2) // throws index out of bounds error
+   * ```
+   */
+  getValue(index: number) {
+    const value = this._col.getValue(index);
+    return value === null
+             ? null
+             : this.type.children.reduce(
+                 (xs, f, i) => ({...xs, [f.name]: value.getColumnByIndex(i).getValue(0)}), {});
+  }
+
   /** @ignore */
   protected __construct(col: Column<Struct<T>>) {
     return new StructSeries(Object.assign(col, {type: fixNames(this.type, col.type)}));

--- a/modules/cudf/src/table.ts
+++ b/modules/cudf/src/table.ts
@@ -22,7 +22,6 @@ import {CSVTypeMap, ReadCSVOptions} from './types/csv';
 import {TableWriteCSVOptions} from './types/csv';
 import {Bool8, DataType, IndexType, Int32} from './types/dtypes';
 import {DuplicateKeepOption, NullOrder} from './types/enums';
-import {TypeMap} from './types/mappings';
 import {ReadORCOptions, TableWriteORCOptions} from './types/orc';
 import {ReadParquetOptions, TableWriteParquetOptions} from './types/parquet';
 
@@ -167,10 +166,10 @@ export interface Table {
    *   of its values are out of bounds (default: false).
    * @param memoryResource An optional MemoryResource used to allocate the result's device memory.
    */
-  scatterScalar<T extends TypeMap = any>(source: (Scalar<T[keyof T]>)[],
-                                         indices: Column<Int32>,
-                                         check_bounds?: boolean,
-                                         memoryResource?: MemoryResource): Table;
+  scatterScalar<T extends Scalar[]>(source: T,
+                                    indices: Column<Int32>,
+                                    check_bounds?: boolean,
+                                    memoryResource?: MemoryResource): Table;
 
   /**
    * Scatters a Table of values into this Table according to provided indices.

--- a/modules/cudf/src/types/dtypes.ts
+++ b/modules/cudf/src/types/dtypes.ts
@@ -183,7 +183,7 @@ export interface Utf8String extends arrow.Utf8 {
 }
 export class Utf8String extends arrow.Utf8 {
   scalar(value: any) {  //
-    return new Scalar({type: new Utf8String, value: '' + value});
+    return new Scalar({type: new Utf8String, value: '' + <string>value});
   }
 }
 

--- a/modules/cudf/src/types/dtypes.ts
+++ b/modules/cudf/src/types/dtypes.ts
@@ -12,9 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {
+  Float32Buffer,
+  Float64Buffer,
+  Int16Buffer,
+  Int32Buffer,
+  Int64Buffer,
+  Int8Buffer,
+  Uint16Buffer,
+  Uint32Buffer,
+  Uint64Buffer,
+  Uint8Buffer,
+  Uint8ClampedBuffer,
+} from '@rapidsai/cuda';
 import * as arrow from 'apache-arrow';
+
 import {Column} from '../column';
-import {TypeMap} from './mappings';
+import {DataFrame, SeriesMap} from '../data_frame';
+import {Scalar} from '../scalar';
+import {Series} from '../series';
+import {Table} from '../table';
+
+import {ColumnsMap, TypeMap} from './mappings';
 
 export type FloatingPoint = Float32|Float64;
 export type IndexType     = Int8|Int16|Int32|Uint8|Uint16|Uint32;
@@ -24,25 +43,49 @@ export type Timestamp =
   TimestampDay|TimestampSecond|TimestampMillisecond|TimestampMicrosecond|TimestampNanosecond;
 export type DataType = Numeric|Utf8String|List|Struct|Timestamp|Categorical;
 
+const ab  = new ArrayBuffer(16);
+const i8  = new Int8Array(ab);
+const i16 = new Int16Array(ab);
+const i32 = new Int32Array(ab);
+const i64 = new BigInt64Array(ab);
+const u8  = new Uint8Array(ab);
+const u16 = new Uint16Array(ab);
+const u32 = new Uint32Array(ab);
+const u64 = new BigUint64Array(ab);
+const f32 = new Float32Array(ab);
+const f64 = new Float64Array(ab);
+
 export interface Int8 extends arrow.Int8 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Int8 extends arrow.Int8 {}
+export class Int8 extends arrow.Int8 {
+  scalar(value: any) {  //
+    return new Scalar({type: new Int8, value: (i8[0] = value)});
+  }
+}
 (Int8.prototype as any).BYTES_PER_ELEMENT = 1;
 
 export interface Int16 extends arrow.Int16 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Int16 extends arrow.Int16 {}
+export class Int16 extends arrow.Int16 {
+  scalar(value: any) {  //
+    return new Scalar({type: new Int16, value: (i16[0] = value)});
+  }
+}
 (Int16.prototype as any).BYTES_PER_ELEMENT = 2;
 
 export interface Int32 extends arrow.Int32 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Int32 extends arrow.Int32 {}
+export class Int32 extends arrow.Int32 {
+  scalar(value: any) {  //
+    return new Scalar({type: new Int32, value: (i32[0] = value)});
+  }
+}
 (Int32.prototype as any).BYTES_PER_ELEMENT = 4;
 
 export interface Int64 extends arrow.Int64 {
@@ -50,28 +93,44 @@ export interface Int64 extends arrow.Int64 {
   scalarType: bigint;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Int64 extends arrow.Int64 {}
+export class Int64 extends arrow.Int64 {
+  scalar(value: any) {  //
+    return new Scalar({type: new Int64, value: (i64[0] = value)});
+  }
+}
 (Int64.prototype as any).BYTES_PER_ELEMENT = 8;
 
 export interface Uint8 extends arrow.Uint8 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Uint8 extends arrow.Uint8 {}
+export class Uint8 extends arrow.Uint8 {
+  scalar(value: any) {  //
+    return new Scalar({type: new Uint8, value: (u8[0] = value)});
+  }
+}
 (Uint8.prototype as any).BYTES_PER_ELEMENT = 1;
 
 export interface Uint16 extends arrow.Uint16 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Uint16 extends arrow.Uint16 {}
+export class Uint16 extends arrow.Uint16 {
+  scalar(value: any) {  //
+    return new Scalar({type: new Uint16, value: (u16[0] = value)});
+  }
+}
 (Uint16.prototype as any).BYTES_PER_ELEMENT = 2;
 
 export interface Uint32 extends arrow.Uint32 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Uint32 extends arrow.Uint32 {}
+export class Uint32 extends arrow.Uint32 {
+  scalar(value: any) {  //
+    return new Scalar({type: new Uint32, value: (u32[0] = value)});
+  }
+}
 (Uint32.prototype as any).BYTES_PER_ELEMENT = 4;
 
 export interface Uint64 extends arrow.Uint64 {
@@ -79,71 +138,147 @@ export interface Uint64 extends arrow.Uint64 {
   scalarType: bigint;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Uint64 extends arrow.Uint64 {}
+export class Uint64 extends arrow.Uint64 {
+  scalar(value: any) {  //
+    return new Scalar({type: new Uint64, value: (u64[0] = value)});
+  }
+}
 (Uint64.prototype as any).BYTES_PER_ELEMENT = 8;
 
 export interface Float32 extends arrow.Float32 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Float32 extends arrow.Float32 {}
+export class Float32 extends arrow.Float32 {
+  scalar(value: any) {  //
+    return new Scalar({type: new Float32, value: (f32[0] = value)});
+  }
+}
 (Float32.prototype as any).BYTES_PER_ELEMENT = 4;
 
 export interface Float64 extends arrow.Float64 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Float64 extends arrow.Float64 {}
+export class Float64 extends arrow.Float64 {
+  scalar(value: any) {  //
+    return new Scalar({type: new Float64, value: (f64[0] = value)});
+  }
+}
 (Float64.prototype as any).BYTES_PER_ELEMENT = 8;
 
 export interface Bool8 extends arrow.Bool {
   scalarType: boolean;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Bool8 extends arrow.Bool {}
+export class Bool8 extends arrow.Bool {
+  scalar(value: any) {  //
+    return new Scalar({type: new Bool8, value: (u8[0] = +!!value) === 1});
+  }
+}
 (Bool8.prototype as any).BYTES_PER_ELEMENT = 1;
 
 export interface Utf8String extends arrow.Utf8 {
   scalarType: string;
 }
-export class Utf8String extends arrow.Utf8 {}
+export class Utf8String extends arrow.Utf8 {
+  scalar(value: any) {  //
+    return new Scalar({type: new Utf8String, value: '' + value});
+  }
+}
 
 export interface List<T extends DataType = any> extends arrow.List<T> {
   childType: T;
   scalarType: Column<T>;
 }
-export class List<T extends DataType = any> extends arrow.List<T> {}
+export class List<T extends DataType = any> extends arrow.List<T> {
+  scalar(value: Int8Array|Int8Buffer): Scalar<List<Int8>>;
+  scalar(value: Int16Array|Int16Buffer): Scalar<List<Int16>>;
+  scalar(value: Int32Array|Int32Buffer): Scalar<List<Int32>>;
+  scalar(value: Uint8Array|Uint8Buffer|Uint8ClampedArray|Uint8ClampedBuffer): Scalar<List<Uint8>>;
+  scalar(value: Uint16Array|Uint16Buffer): Scalar<List<Uint16>>;
+  scalar(value: Uint32Array|Uint32Buffer): Scalar<List<Uint32>>;
+  scalar(value: BigUint64Array|Uint64Buffer): Scalar<List<Uint64>>;
+  scalar(value: Float32Array|Float32Buffer): Scalar<List<Float32>>;
+  scalar(value: (string|null|undefined)[]): Scalar<List<Utf8String>>;
+  scalar(value: (number|null|undefined)[]|Float64Array|Float64Buffer): Scalar<List<Float64>>;
+  scalar(value: (bigint|null|undefined)[]|BigInt64Array|Int64Buffer): Scalar<List<Int64>>;
+  scalar(value: (boolean|null|undefined)[]): Scalar<List<Bool8>>;
+  scalar(value: (Date|null|undefined)[]): Scalar<List<TimestampMillisecond>>;
+  scalar(value: (string|null|undefined)[][]): Scalar<List<List<Utf8String>>>;
+  scalar(value: (number|null|undefined)[][]): Scalar<List<List<Float64>>>;
+  scalar(value: (bigint|null|undefined)[][]): Scalar<List<List<Int64>>>;
+  scalar(value: (boolean|null|undefined)[][]): Scalar<List<List<Bool8>>>;
+  scalar(value: (Date|null|undefined)[][]): Scalar<List<List<TimestampMillisecond>>>;
+  scalar(value: any) {
+    const {type, _col: col} = Series.new(value);
+    return new Scalar({type: new List(new arrow.Field('0', type)), value: col});
+  }
+}
 
 export interface Struct<T extends TypeMap = any> extends arrow.Struct<T> {
   childTypes: T;
   scalarType: {[P in keyof T]: T[P]['scalarType']};
 }
-export class Struct<T extends TypeMap = any> extends arrow.Struct<T> {}
+export class Struct<T extends TypeMap = any> extends arrow.Struct<T> {
+  scalar<T extends TypeMap>(value: DataFrame<T>): Scalar<Struct<T>>;
+  scalar<T extends TypeMap>(value: SeriesMap<T>): Scalar<Struct<T>>;
+  scalar<T extends TypeMap>(value: ColumnsMap<T>): Scalar<Struct<T>>;
+  scalar(value: any) {
+    if (value instanceof Table) {
+      value = new DataFrame(Array.from({length: value.numColumns}, (_, i) => i)
+                              .reduce((xs, x) => ({...xs, [x]: value.getColumnByIndex(x)}), {}));
+    }
+    const frame = value instanceof DataFrame ? value : new DataFrame(value);
+    const type  = new Struct(frame.names.map((name) => arrow.Field.new(name, frame.types[name])));
+    return new Scalar({type, value: frame.asTable()});
+  }
+}
 
 export interface TimestampDay extends arrow.DateDay {
   scalarType: Date;
 }
-export class TimestampDay extends arrow.DateDay {}
+export class TimestampDay extends arrow.DateDay {
+  scalar(value: any) {  //
+    return new Scalar({type: new TimestampDay, value: new Date(value)});
+  }
+}
 
 export interface TimestampSecond extends arrow.TimestampSecond {
   scalarType: Date;
 }
-export class TimestampSecond extends arrow.TimestampSecond {}
+export class TimestampSecond extends arrow.TimestampSecond {
+  scalar(value: any) {  //
+    return new Scalar({type: new TimestampSecond, value: new Date(value)});
+  }
+}
 
 export interface TimestampMillisecond extends arrow.TimestampMillisecond {
   scalarType: Date;
 }
-export class TimestampMillisecond extends arrow.TimestampMillisecond {}
+export class TimestampMillisecond extends arrow.TimestampMillisecond {
+  scalar(value: any) {  //
+    return new Scalar({type: new TimestampMillisecond, value: new Date(value)});
+  }
+}
 
 export interface TimestampMicrosecond extends arrow.TimestampMicrosecond {
   scalarType: Date;
 }
-export class TimestampMicrosecond extends arrow.TimestampMicrosecond {}
+export class TimestampMicrosecond extends arrow.TimestampMicrosecond {
+  scalar(value: any) {  //
+    return new Scalar({type: new TimestampMicrosecond, value: new Date(value)});
+  }
+}
 
 export interface TimestampNanosecond extends arrow.TimestampNanosecond {
   scalarType: Date;
 }
-export class TimestampNanosecond extends arrow.TimestampNanosecond {}
+export class TimestampNanosecond extends arrow.TimestampNanosecond {
+  scalar(value: any) {  //
+    return new Scalar({type: new TimestampNanosecond, value: new Date(value)});
+  }
+}
 
 export interface Categorical<T extends DataType = any> extends arrow.Dictionary<T, Uint32> {
   scalarType: T['scalarType'];

--- a/modules/cudf/src/types/dtypes.ts
+++ b/modules/cudf/src/types/dtypes.ts
@@ -111,13 +111,11 @@ export interface Utf8String extends arrow.Utf8 {
 export class Utf8String extends arrow.Utf8 {}
 
 export interface List<T extends DataType = any> extends arrow.List<T> {
-  childType: T;
   scalarType: Column<T>;
 }
 export class List<T extends DataType = any> extends arrow.List<T> {}
 
 export interface Struct<T extends TypeMap = any> extends arrow.Struct<T> {
-  childTypes: T;
   scalarType: Table;
 }
 export class Struct<T extends TypeMap = any> extends arrow.Struct<T> {}

--- a/modules/cudf/src/types/dtypes.ts
+++ b/modules/cudf/src/types/dtypes.ts
@@ -12,24 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  Float32Buffer,
-  Float64Buffer,
-  Int16Buffer,
-  Int32Buffer,
-  Int64Buffer,
-  Int8Buffer,
-  Uint16Buffer,
-  Uint32Buffer,
-  Uint64Buffer,
-  Uint8Buffer,
-  Uint8ClampedBuffer,
-} from '@rapidsai/cuda';
 import * as arrow from 'apache-arrow';
 
 import {Column} from '../column';
-import {Scalar} from '../scalar';
-import {Series} from '../series';
 import {Table} from '../table';
 import {TypeMap} from './mappings';
 
@@ -41,49 +26,25 @@ export type Timestamp =
   TimestampDay|TimestampSecond|TimestampMillisecond|TimestampMicrosecond|TimestampNanosecond;
 export type DataType = Numeric|Utf8String|List|Struct|Timestamp|Categorical;
 
-const ab  = new ArrayBuffer(16);
-const i8  = new Int8Array(ab);
-const i16 = new Int16Array(ab);
-const i32 = new Int32Array(ab);
-const i64 = new BigInt64Array(ab);
-const u8  = new Uint8Array(ab);
-const u16 = new Uint16Array(ab);
-const u32 = new Uint32Array(ab);
-const u64 = new BigUint64Array(ab);
-const f32 = new Float32Array(ab);
-const f64 = new Float64Array(ab);
-
 export interface Int8 extends arrow.Int8 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Int8 extends arrow.Int8 {
-  scalar(value: any) {  //
-    return new Scalar({type: new Int8, value: (i8[0] = value)});
-  }
-}
+export class Int8 extends arrow.Int8 {}
 (Int8.prototype as any).BYTES_PER_ELEMENT = 1;
 
 export interface Int16 extends arrow.Int16 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Int16 extends arrow.Int16 {
-  scalar(value: any) {  //
-    return new Scalar({type: new Int16, value: (i16[0] = value)});
-  }
-}
+export class Int16 extends arrow.Int16 {}
 (Int16.prototype as any).BYTES_PER_ELEMENT = 2;
 
 export interface Int32 extends arrow.Int32 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Int32 extends arrow.Int32 {
-  scalar(value: any) {  //
-    return new Scalar({type: new Int32, value: (i32[0] = value)});
-  }
-}
+export class Int32 extends arrow.Int32 {}
 (Int32.prototype as any).BYTES_PER_ELEMENT = 4;
 
 export interface Int64 extends arrow.Int64 {
@@ -91,44 +52,28 @@ export interface Int64 extends arrow.Int64 {
   scalarType: bigint;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Int64 extends arrow.Int64 {
-  scalar(value: any) {  //
-    return new Scalar({type: new Int64, value: (i64[0] = value)});
-  }
-}
+export class Int64 extends arrow.Int64 {}
 (Int64.prototype as any).BYTES_PER_ELEMENT = 8;
 
 export interface Uint8 extends arrow.Uint8 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Uint8 extends arrow.Uint8 {
-  scalar(value: any) {  //
-    return new Scalar({type: new Uint8, value: (u8[0] = value)});
-  }
-}
+export class Uint8 extends arrow.Uint8 {}
 (Uint8.prototype as any).BYTES_PER_ELEMENT = 1;
 
 export interface Uint16 extends arrow.Uint16 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Uint16 extends arrow.Uint16 {
-  scalar(value: any) {  //
-    return new Scalar({type: new Uint16, value: (u16[0] = value)});
-  }
-}
+export class Uint16 extends arrow.Uint16 {}
 (Uint16.prototype as any).BYTES_PER_ELEMENT = 2;
 
 export interface Uint32 extends arrow.Uint32 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Uint32 extends arrow.Uint32 {
-  scalar(value: any) {  //
-    return new Scalar({type: new Uint32, value: (u32[0] = value)});
-  }
-}
+export class Uint32 extends arrow.Uint32 {}
 (Uint32.prototype as any).BYTES_PER_ELEMENT = 4;
 
 export interface Uint64 extends arrow.Uint64 {
@@ -136,145 +81,71 @@ export interface Uint64 extends arrow.Uint64 {
   scalarType: bigint;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Uint64 extends arrow.Uint64 {
-  scalar(value: any) {  //
-    return new Scalar({type: new Uint64, value: (u64[0] = value)});
-  }
-}
+export class Uint64 extends arrow.Uint64 {}
 (Uint64.prototype as any).BYTES_PER_ELEMENT = 8;
 
 export interface Float32 extends arrow.Float32 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Float32 extends arrow.Float32 {
-  scalar(value: any) {  //
-    return new Scalar({type: new Float32, value: (f32[0] = value)});
-  }
-}
+export class Float32 extends arrow.Float32 {}
 (Float32.prototype as any).BYTES_PER_ELEMENT = 4;
 
 export interface Float64 extends arrow.Float64 {
   scalarType: number;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Float64 extends arrow.Float64 {
-  scalar(value: any) {  //
-    return new Scalar({type: new Float64, value: (f64[0] = value)});
-  }
-}
+export class Float64 extends arrow.Float64 {}
 (Float64.prototype as any).BYTES_PER_ELEMENT = 8;
 
 export interface Bool8 extends arrow.Bool {
   scalarType: boolean;
   readonly BYTES_PER_ELEMENT: number;
 }
-export class Bool8 extends arrow.Bool {
-  scalar(value: any) {  //
-    return new Scalar({type: new Bool8, value: (u8[0] = +!!value) === 1});
-  }
-}
+export class Bool8 extends arrow.Bool {}
 (Bool8.prototype as any).BYTES_PER_ELEMENT = 1;
 
 export interface Utf8String extends arrow.Utf8 {
   scalarType: string;
 }
-export class Utf8String extends arrow.Utf8 {
-  scalar(value: any) {  //
-    return new Scalar({type: new Utf8String, value: '' + <string>value});
-  }
-}
+export class Utf8String extends arrow.Utf8 {}
 
 export interface List<T extends DataType = any> extends arrow.List<T> {
   childType: T;
   scalarType: Column<T>;
 }
-export class List<T extends DataType = any> extends arrow.List<T> {
-  scalar(value: Int8Array|Int8Buffer): Scalar<List<Int8>>;
-  scalar(value: Int16Array|Int16Buffer): Scalar<List<Int16>>;
-  scalar(value: Int32Array|Int32Buffer): Scalar<List<Int32>>;
-  scalar(value: Uint8Array|Uint8Buffer|Uint8ClampedArray|Uint8ClampedBuffer): Scalar<List<Uint8>>;
-  scalar(value: Uint16Array|Uint16Buffer): Scalar<List<Uint16>>;
-  scalar(value: Uint32Array|Uint32Buffer): Scalar<List<Uint32>>;
-  scalar(value: BigUint64Array|Uint64Buffer): Scalar<List<Uint64>>;
-  scalar(value: Float32Array|Float32Buffer): Scalar<List<Float32>>;
-  scalar(value: (string|null|undefined)[]): Scalar<List<Utf8String>>;
-  scalar(value: (number|null|undefined)[]|Float64Array|Float64Buffer): Scalar<List<Float64>>;
-  scalar(value: (bigint|null|undefined)[]|BigInt64Array|Int64Buffer): Scalar<List<Int64>>;
-  scalar(value: (boolean|null|undefined)[]): Scalar<List<Bool8>>;
-  scalar(value: (Date|null|undefined)[]): Scalar<List<TimestampMillisecond>>;
-  scalar(value: (string|null|undefined)[][]): Scalar<List<List<Utf8String>>>;
-  scalar(value: (number|null|undefined)[][]): Scalar<List<List<Float64>>>;
-  scalar(value: (bigint|null|undefined)[][]): Scalar<List<List<Int64>>>;
-  scalar(value: (boolean|null|undefined)[][]): Scalar<List<List<Bool8>>>;
-  scalar(value: (Date|null|undefined)[][]): Scalar<List<List<TimestampMillisecond>>>;
-  scalar(value: any) {
-    const {type, _col: col} = Series.new(value);
-    return new Scalar({type: new List(new arrow.Field('0', type)), value: col});
-  }
-}
+export class List<T extends DataType = any> extends arrow.List<T> {}
 
 export interface Struct<T extends TypeMap = any> extends arrow.Struct<T> {
   childTypes: T;
   scalarType: Table;
 }
-export class Struct<T extends TypeMap = any> extends arrow.Struct<T> {
-  scalar<T extends TypeMap>(value: {[P in keyof T]: T[P]['scalarType']}): Scalar<Struct<T>> {
-    const columns = [] as Column[];
-    const fields  = [] as arrow.Field[];
-    for (const [name, val] of Object.entries(value)) {
-      const {type, _col: col} = Series.new([val]);
-      columns.push(col);
-      fields.push(arrow.Field.new({name, type}));
-    }
-    return new Scalar({type: new Struct(fields), value: new Table({columns})});
-  }
-}
+export class Struct<T extends TypeMap = any> extends arrow.Struct<T> {}
 
 export interface TimestampDay extends arrow.DateDay {
   scalarType: Date;
 }
-export class TimestampDay extends arrow.DateDay {
-  scalar(value: any) {  //
-    return new Scalar({type: new TimestampDay, value: new Date(value)});
-  }
-}
+export class TimestampDay extends arrow.DateDay {}
 
 export interface TimestampSecond extends arrow.TimestampSecond {
   scalarType: Date;
 }
-export class TimestampSecond extends arrow.TimestampSecond {
-  scalar(value: any) {  //
-    return new Scalar({type: new TimestampSecond, value: new Date(value)});
-  }
-}
+export class TimestampSecond extends arrow.TimestampSecond {}
 
 export interface TimestampMillisecond extends arrow.TimestampMillisecond {
   scalarType: Date;
 }
-export class TimestampMillisecond extends arrow.TimestampMillisecond {
-  scalar(value: any) {  //
-    return new Scalar({type: new TimestampMillisecond, value: new Date(value)});
-  }
-}
+export class TimestampMillisecond extends arrow.TimestampMillisecond {}
 
 export interface TimestampMicrosecond extends arrow.TimestampMicrosecond {
   scalarType: Date;
 }
-export class TimestampMicrosecond extends arrow.TimestampMicrosecond {
-  scalar(value: any) {  //
-    return new Scalar({type: new TimestampMicrosecond, value: new Date(value)});
-  }
-}
+export class TimestampMicrosecond extends arrow.TimestampMicrosecond {}
 
 export interface TimestampNanosecond extends arrow.TimestampNanosecond {
   scalarType: Date;
 }
-export class TimestampNanosecond extends arrow.TimestampNanosecond {
-  scalar(value: any) {  //
-    return new Scalar({type: new TimestampNanosecond, value: new Date(value)});
-  }
-}
+export class TimestampNanosecond extends arrow.TimestampNanosecond {}
 
 export interface Categorical<T extends DataType = any> extends arrow.Dictionary<T, Uint32> {
   scalarType: T['scalarType'];

--- a/modules/cudf/src/types/mappings.ts
+++ b/modules/cudf/src/types/mappings.ts
@@ -92,8 +92,8 @@ export type CommonType<T extends DataType, R extends DataType> =
     : T extends Float32 ? CommonType_Float32<R>
     : T extends Float64 ? CommonType_Float64<R>
     : never :
-  T extends List ? R extends List ? List<CommonType<T['childType'], R['childType']>> : never :
-  T extends Struct ? R extends Struct ? Struct<CommonTypes<T['childTypes'], R['childTypes']>> : never :
+  T extends List ? R extends List ? List<CommonType<T['valueType'], R['valueType']>> : never :
+  T extends Struct ? R extends Struct ? Struct<CommonTypes<T['dataTypes'], R['dataTypes']>> : never :
   T extends Categorical ? R extends Categorical ? Categorical<CommonType<T['dictionary'], R['dictionary']>> : never :
   never;
 

--- a/modules/cudf/test/cudf-data-frame-tests.ts
+++ b/modules/cudf/test/cudf-data-frame-tests.ts
@@ -161,6 +161,26 @@ test('DataFrame.drop', () => {
   expect(table_1.names).toStrictEqual(['col_0', 'col_2']);
 });
 
+test('DataFrame.rename', () => {
+  const length = 100;
+  const col_0  = Series.new({type: new Int32(), data: new Int32Buffer(length)});
+
+  const col_1 = Series.new({
+    type: new Bool8(),
+    data: new Uint8Buffer(length),
+    nullMask: new Uint8Buffer(64),
+  });
+
+  const col_2 = Series.new({type: new Int32(), data: new Int32Buffer(length)});
+
+  const table_0 = new DataFrame({col_0, col_1, col_2});
+
+  const table_1 = table_0.rename({col_1: 'col_1_renamed', col_2: 2});
+  expect(table_1.numColumns).toBe(3);
+  expect(table_1.numRows).toBe(length);
+  expect(table_1.names).toStrictEqual(['2', 'col_0', 'col_1_renamed']);
+});
+
 test('DataFrame.orderBy (ascending, non-null)', () => {
   const col    = Series.new({type: new Int32(), data: new Int32Buffer([1, 3, 5, 4, 2, 0])});
   const df     = new DataFrame({'a': col});

--- a/modules/cuml/.vscode/launch.json
+++ b/modules/cuml/.vscode/launch.json
@@ -20,6 +20,7 @@
             "request": "launch",
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
             "skipFiles": [
                 "<node_internals>/**",

--- a/modules/cuspatial/.vscode/launch.json
+++ b/modules/cuspatial/.vscode/launch.json
@@ -20,6 +20,7 @@
             "request": "launch",
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
             "skipFiles": [
                 "<node_internals>/**",

--- a/modules/cuspatial/src/geometry.ts
+++ b/modules/cuspatial/src/geometry.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,17 +21,14 @@ import {computePolygonBoundingBoxes, computePolylineBoundingBoxes} from './addon
 export type BoundingBoxes<T extends FloatingPoint> =
   DataFrame<{x_min: T, y_min: T, x_max: T, y_max: T}>;
 
-export type Coord<T extends FloatingPoint = FloatingPoint>  = T;
-export type Coords<T extends FloatingPoint = FloatingPoint> = Series<T>;
+export type Point<T extends FloatingPoint>  = Struct<{x: T, y: T}>;
+export type Points<T extends FloatingPoint> = Series<Point<T>>;
 
-export type Point<T extends Coord = FloatingPoint>          = Struct<{x: T, y: T}>;
-export type Points<T extends FloatingPoint = FloatingPoint> = Series<Point<Coord<T>>>;
+export type Polyline<T extends FloatingPoint>  = List<Point<T>>;
+export type Polylines<T extends FloatingPoint> = Series<Polyline<T>>;
 
-export type Polyline<T extends Point = Point>                  = List<T>;
-export type Polylines<T extends FloatingPoint = FloatingPoint> = Series<List<Point<T>>>;
-
-export type Polygon<T extends Polyline = Polyline>            = List<T>;
-export type Polygons<T extends FloatingPoint = FloatingPoint> = Series<List<Polyline<Point<T>>>>;
+export type Polygon<T extends FloatingPoint>  = List<Polyline<T>>;
+export type Polygons<T extends FloatingPoint> = Series<Polygon<T>>;
 
 export function makePoints<T extends Series<FloatingPoint>>(x: T, y: T): Points<T['type']> {
   return Series.new({

--- a/modules/cuspatial/src/quadtree.ts
+++ b/modules/cuspatial/src/quadtree.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import {
 } from './addon';
 import {
   BoundingBoxes,
-  Coords,
   polygonBoundingBoxes,
   Polygons,
   polylineBoundingBoxes,
@@ -83,7 +82,7 @@ export class Quadtree<T extends FloatingPoint> {
    * @param options.memoryResource Optional resource to use for output device memory allocations.
    * @returns Quadtree
    */
-  static new<T extends Coords>(options: {
+  static new<T extends Series<FloatingPoint>>(options: {
     x: T,
     y: T,
     xMin: number,

--- a/modules/deck.gl/.vscode/launch.json
+++ b/modules/deck.gl/.vscode/launch.json
@@ -10,6 +10,7 @@
             "request": "launch",
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
             "skipFiles": [
                 "<node_internals>/**",

--- a/modules/deck.gl/src/layers/graph.ts
+++ b/modules/deck.gl/src/layers/graph.ts
@@ -330,7 +330,7 @@ const copyUpdatesIntoBuffers = ({
   numNodesLoaded,
   edgePositionRanges,
 }: any) => {
-  const updatedBufferNames = (names: string[], {attributes}: any) =>
+  const updatedBufferNames = (names: string[], {attributes = {}}: any) =>
     names.filter((name) => attributes[name]);
   const copyUpdateIntoBuffers = (buffers: any, names: string[], update: any) => {
     for (const name of updatedBufferNames(names, update)) {

--- a/modules/demo/.vscode/launch.json
+++ b/modules/demo/.vscode/launch.json
@@ -23,6 +23,7 @@
             "runtimeArgs": ["--experimental-vm-modules"],
             "cwd": "${workspaceFolder}/${input:DEMO_NAME}",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "skipFiles": [
                 // "**/node_modules/**",
                 // "<node_internals>/**",

--- a/modules/demo/spatial/color.js
+++ b/modules/demo/spatial/color.js
@@ -16,34 +16,24 @@ const goldenRatioConjugate = 0.618033988749895;
 
 export class ColorMapper {
   constructor(hue = 0.99, saturation = 0.99, brightness = 0.99) {
-    this._h = hue % 1;
-    this._s = saturation % 1;
-    this._v = brightness % 1;
+    this._h   = hue % 1;
+    this._s   = saturation % 1;
+    this._v   = brightness % 1;
     this._map = Object.create(null);
   }
-  get(id, colors = [], index = 0) {
-    [
-      colors[index * 4 + 0],
-      colors[index * 4 + 1],
-      colors[index * 4 + 2]
-    ] = this._map[id] || (this._map[id] = this.generate());
-    colors[index * 4 + 3] = 255;
-    return colors;
-  }
+  get(id) { return this._map[id] || (this._map[id] = this.generate()); }
   generate() {
-    const rgb = HSVtoRGB(this._h, this._s, this._v);
-    this._h = (this._h + goldenRatioConjugate) % 1;
-    return rgb;
+    const rgba = HSVtoRGBA(this._h, this._s, this._v);
+    this._h    = (this._h + goldenRatioConjugate) % 1;
+    return rgba;
   }
 }
 
 // # HSV values in [0..1]
 // # returns [r, g, b] values from 0 to 255
-function HSVtoRGB(h, s, v) {
+function HSVtoRGBA(h, s, v) {
   var r, g, b, i, f, p, q, t;
-  if (arguments.length === 1) {
-    s = h.s, v = h.v, h = h.h;
-  }
+  if (arguments.length === 1) { s = h.s, v = h.v, h = h.h; }
   i = Math.floor(h * 6);
   f = h * 6 - i;
   p = v * (1 - s);
@@ -58,8 +48,9 @@ function HSVtoRGB(h, s, v) {
     case 5: r = v, g = p, b = q; break;
   }
   return [
-    Math.round(r * 255), // r
-    Math.round(g * 255), // g
-    Math.round(b * 255), // b
+    Math.round(r * 255),  // r
+    Math.round(g * 255),  // g
+    Math.round(b * 255),  // b
+    255,                  // a
   ]
 }

--- a/modules/demo/spatial/util.js
+++ b/modules/demo/spatial/util.js
@@ -305,13 +305,16 @@ export function filterPointsAndColorsByLevel(colors, levels, points, polyIds) {
  * @param {Map<number, [number, number, number, number]>} colorMap
  */
 export function copyPolygonsDtoH(tracts, colorMap) {
-  return [...tracts.toArrow()].map(({id, polygon}) => {
+  console.time(`copy census tracts DtoH (${tracts.numRows.toLocaleString()} tracts)`);
+  const result = [...tracts.toArrow()].map(({id, polygon}) => {
     return {
       id,
       color: colorMap.get(id),
       rings: [...polygon].map((ring) => [...ring].map(({x, y}) => [x, y])),
     };
   });
+  console.timeEnd(`copy census tracts DtoH (${tracts.numRows.toLocaleString()} tracts)`);
+  return result;
 }
 
 /**
@@ -319,7 +322,8 @@ export function copyPolygonsDtoH(tracts, colorMap) {
  * @param {Map<number, [number, number, number, number]>} colorMap
  */
 export function copyPolygonVerticesDtoH(tracts, colorMap) {
-  return [...tracts.toArrow()].flatMap(({id, polygon}) => {
+  console.time(`copy census tract vertices DtoH (${tracts.numRows.toLocaleString()} tracts)`);
+  const result = [...tracts.toArrow()].flatMap(({id, polygon}) => {
     const color = colorMap.get(id);
     return [...polygon].flatMap((ring) => [...ring].map(({x, y}) => ({
                                                           id,
@@ -329,6 +333,8 @@ export function copyPolygonVerticesDtoH(tracts, colorMap) {
                                                           strokeWidth: Math.max(1, (id % 3)),
                                                         })));
   });
+  console.timeEnd(`copy census tract vertices DtoH (${tracts.numRows.toLocaleString()} tracts)`);
+  return result;
 }
 
 const sleep = (t) => new Promise((r) => setTimeout(r, t));

--- a/modules/glfw/.vscode/launch.json
+++ b/modules/glfw/.vscode/launch.json
@@ -20,6 +20,7 @@
             "request": "launch",
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
             "skipFiles": [
                 "<node_internals>/**",

--- a/modules/io/.vscode/launch.json
+++ b/modules/io/.vscode/launch.json
@@ -139,7 +139,7 @@
             "id": "TEST_FILE",
             "command": "shellCommand.execute",
             "args": {
-                "cwd": "${workspaceFolder}/modules/sql",
+                "cwd": "${workspaceFolder}/modules/io",
                 "description": "Select a file to debug",
                 "command": "./node_modules/.bin/jest --listTests | sed -r \"s@$PWD/test/@@g\"",
             }

--- a/modules/jsdom/.vscode/launch.json
+++ b/modules/jsdom/.vscode/launch.json
@@ -10,6 +10,7 @@
             "request": "launch",
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
             // "skipFiles": [
             //     "<node_internals>/**",

--- a/modules/rmm/.vscode/launch.json
+++ b/modules/rmm/.vscode/launch.json
@@ -20,6 +20,7 @@
             "request": "launch",
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
             "skipFiles": [
                 "<node_internals>/**",

--- a/modules/webgl/.vscode/launch.json
+++ b/modules/webgl/.vscode/launch.json
@@ -20,6 +20,7 @@
             "request": "launch",
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
             "skipFiles": [
                 "<node_internals>/**",

--- a/node-rapids.code-workspace
+++ b/node-rapids.code-workspace
@@ -174,7 +174,6 @@
             "editor.defaultFormatter": "vscode.typescript-language-features"
         },
         "clangd.path": "/usr/bin/clangd",
-        "clangd.semanticHighlighting": false,
         "clangd.arguments": [
             "--log=info",
             "--pch-storage=disk",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@ampproject/remapping@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.1.tgz#9a04a4aba7b8323b65498d9554a1bdd15d960296"
+  integrity sha512-EldHF4Ufj3NL9yCAmYrPzY+3/Yqrzxu24F4Mu4nRjK3w70AKYRmhuLwGZdA9JeoDsbIwkgGkbqUK2INuF582Og==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/trace-mapping" "^0.2.2"
+    sourcemap-codec "1.4.8"
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -17,9 +26,9 @@
     "@babel/highlight" "^7.16.7"
 
 "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.15.0", "@babel/compat-data@^7.16.4":
-  version "7.16.8"
-  resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.8.tgz#31560f9f29fdf1868de8cb55049538a1b9732a60"
-  integrity sha512-m7OkX0IdKLKPpBlJtF561YJal5y/jyI5fNfWbPxh2D/nbzzGI4qRyrD8xO2jB24u7l+5I2a43scCG2IrfjC50Q==
+  version "7.17.0"
+  resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz#86850b8597ea6962089770952075dcaabb8dba34"
+  integrity sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==
 
 "@babel/core@7.15.5":
   version "7.15.5"
@@ -43,32 +52,32 @@
     source-map "^0.5.0"
 
 "@babel/core@^7.1.0", "@babel/core@^7.12.3", "@babel/core@^7.7.5":
-  version "7.16.12"
-  resolved "https://registry.npmjs.org/@babel/core/-/core-7.16.12.tgz#5edc53c1b71e54881315923ae2aedea2522bb784"
-  integrity sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==
+  version "7.17.0"
+  resolved "https://registry.npmjs.org/@babel/core/-/core-7.17.0.tgz#16b8772b0a567f215839f689c5ded6bb20e864d5"
+  integrity sha512-x/5Ea+RO5MvF9ize5DeVICJoVrNv0Mi2RnIABrZEKYvPEpldXwauPkgvYA17cKa6WpU3LoYvYbuEMFtSNFsarA==
   dependencies:
+    "@ampproject/remapping" "^2.0.0"
     "@babel/code-frame" "^7.16.7"
-    "@babel/generator" "^7.16.8"
+    "@babel/generator" "^7.17.0"
     "@babel/helper-compilation-targets" "^7.16.7"
     "@babel/helper-module-transforms" "^7.16.7"
-    "@babel/helpers" "^7.16.7"
-    "@babel/parser" "^7.16.12"
+    "@babel/helpers" "^7.17.0"
+    "@babel/parser" "^7.17.0"
     "@babel/template" "^7.16.7"
-    "@babel/traverse" "^7.16.10"
-    "@babel/types" "^7.16.8"
+    "@babel/traverse" "^7.17.0"
+    "@babel/types" "^7.17.0"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
     json5 "^2.1.2"
     semver "^6.3.0"
-    source-map "^0.5.0"
 
-"@babel/generator@^7.15.4", "@babel/generator@^7.16.8":
-  version "7.16.8"
-  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz#359d44d966b8cd059d543250ce79596f792f2ebe"
-  integrity sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==
+"@babel/generator@^7.15.4", "@babel/generator@^7.17.0":
+  version "7.17.0"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz#7bd890ba706cd86d3e2f727322346ffdbf98f65e"
+  integrity sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==
   dependencies:
-    "@babel/types" "^7.16.8"
+    "@babel/types" "^7.17.0"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -98,9 +107,9 @@
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.16.10", "@babel/helper-create-class-features-plugin@^7.16.7":
-  version "7.16.10"
-  resolved "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.10.tgz#8a6959b9cc818a88815ba3c5474619e9c0f2c21c"
-  integrity sha512-wDeej0pu3WN/ffTxMNCPW5UCiOav8IcLRxSIyp/9+IF2xJUM9h/OYjg0IJLHaL6F8oU8kqMz9nc1vryXhMsgXg==
+  version "7.17.0"
+  resolved "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.0.tgz#3ba0eae83313d4077319d11a768c46adad026433"
+  integrity sha512-S3+IHG72pJFb0RmJgeXg/TjVKt641ZsLla028haXJjdqCf9eccE5r1JsdO//L7nzTDzXjtC+hwV/lrkEb2+t0Q==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.7"
     "@babel/helper-environment-visitor" "^7.16.7"
@@ -111,12 +120,12 @@
     "@babel/helper-split-export-declaration" "^7.16.7"
 
 "@babel/helper-create-regexp-features-plugin@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.16.7.tgz#0cb82b9bac358eb73bfbd73985a776bfa6b14d48"
-  integrity sha512-fk5A6ymfp+O5+p2yCkXAu5Kyj6v0xh0RBeNcAkYUMDvvAAoxvSKXn+Jb37t/yWFiQVDFK1ELpUTD8/aLhCPu+g==
+  version "7.17.0"
+  resolved "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.17.0.tgz#1dcc7d40ba0c6b6b25618997c5dbfd310f186fe1"
+  integrity sha512-awO2So99wG6KnlE+TPs6rn83gCz5WlEePJDTnLEqbchMVrBeAujURVphRdigsk094VhvZehFoNOihSlcBjwsXA==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.7"
-    regexpu-core "^4.7.1"
+    regexpu-core "^5.0.1"
 
 "@babel/helper-define-polyfill-provider@^0.2.2", "@babel/helper-define-polyfill-provider@^0.2.4":
   version "0.2.4"
@@ -270,14 +279,14 @@
     "@babel/traverse" "^7.16.8"
     "@babel/types" "^7.16.8"
 
-"@babel/helpers@^7.15.4", "@babel/helpers@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.7.tgz#7e3504d708d50344112767c3542fc5e357fffefc"
-  integrity sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==
+"@babel/helpers@^7.15.4", "@babel/helpers@^7.17.0":
+  version "7.17.0"
+  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.0.tgz#79cdf6c66a579f3a7b5e739371bc63ca0306886b"
+  integrity sha512-Xe/9NFxjPwELUvW2dsukcMZIp6XwPSbI4ojFBJuX5ramHuVE22SVcZIwqzdWo5uCgeTXW8qV97lMvSOjq+1+nQ==
   dependencies:
     "@babel/template" "^7.16.7"
-    "@babel/traverse" "^7.16.7"
-    "@babel/types" "^7.16.7"
+    "@babel/traverse" "^7.17.0"
+    "@babel/types" "^7.17.0"
 
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.16.7":
   version "7.16.10"
@@ -288,10 +297,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.15.5", "@babel/parser@^7.16.10", "@babel/parser@^7.16.12", "@babel/parser@^7.16.7":
-  version "7.16.12"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz#9474794f9a650cf5e2f892444227f98e28cdf8b6"
-  integrity sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.15.5", "@babel/parser@^7.16.7", "@babel/parser@^7.17.0":
+  version "7.17.0"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz#f0ac33eddbe214e4105363bb17c3341c5ffcc43c"
+  integrity sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.15.4":
   version "7.16.7"
@@ -960,9 +969,9 @@
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.8", "@babel/runtime@^7.14.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
-  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
+  version "7.17.0"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.0.tgz#b8d142fc0f7664fb3d9b5833fd40dcbab89276c0"
+  integrity sha512-etcO/ohMNaNA2UBdaXBBSX/3aEzFMRrVfaPv8Ptc0k+cWpWW0QFiGZ2XnVqQZI1Cf734LbPGmqBKWESfW4x/dQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -975,19 +984,19 @@
     "@babel/parser" "^7.16.7"
     "@babel/types" "^7.16.7"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.15.4", "@babel/traverse@^7.16.10", "@babel/traverse@^7.16.7", "@babel/traverse@^7.16.8":
-  version "7.16.10"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.10.tgz#448f940defbe95b5a8029975b051f75993e8239f"
-  integrity sha512-yzuaYXoRJBGMlBhsMJoUW7G1UmSb/eXr/JHYM/MsOJgavJibLwASijW7oXBdw3NQ6T0bW7Ty5P/VarOs9cHmqw==
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.15.4", "@babel/traverse@^7.16.7", "@babel/traverse@^7.16.8", "@babel/traverse@^7.17.0":
+  version "7.17.0"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz#3143e5066796408ccc880a33ecd3184f3e75cd30"
+  integrity sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==
   dependencies:
     "@babel/code-frame" "^7.16.7"
-    "@babel/generator" "^7.16.8"
+    "@babel/generator" "^7.17.0"
     "@babel/helper-environment-visitor" "^7.16.7"
     "@babel/helper-function-name" "^7.16.7"
     "@babel/helper-hoist-variables" "^7.16.7"
     "@babel/helper-split-export-declaration" "^7.16.7"
-    "@babel/parser" "^7.16.10"
-    "@babel/types" "^7.16.8"
+    "@babel/parser" "^7.17.0"
+    "@babel/types" "^7.17.0"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -999,10 +1008,10 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.15.4", "@babel/types@^7.15.6", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
-  version "7.16.8"
-  resolved "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz#0ba5da91dd71e0a4e7781a30f22770831062e3c1"
-  integrity sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==
+"@babel/types@^7.0.0", "@babel/types@^7.15.4", "@babel/types@^7.15.6", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
+  version "7.17.0"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
+  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
@@ -1522,6 +1531,19 @@
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
+
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz#b876e3feefb9c8d3aa84014da28b5e52a0640d72"
+  integrity sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==
+
+"@jridgewell/trace-mapping@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.2.2.tgz#77510cc2f6f3b92e78c78de216d42de631b1d7fb"
+  integrity sha512-I9AGQzMPEzQNJgib2YSqciYWazGsXSyu1rEEeaPeM1764ZtnfNTxA5bofzG/POMI3QcvpBUxwecOPZM6ZhkEpg==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    sourcemap-codec "1.4.8"
 
 "@lerna/add@3.21.0":
   version "3.21.0"
@@ -3224,9 +3246,9 @@
     form-data "^3.0.0"
 
 "@types/node@*", "@types/node@>= 8", "@types/node@>=10.0.0":
-  version "17.0.13"
-  resolved "https://registry.npmjs.org/@types/node/-/node-17.0.13.tgz#5ed7ed7c662948335fcad6c412bb42d99ea754e3"
-  integrity sha512-Y86MAxASe25hNzlDbsviXl8jQHb0RDvKt4c40ZJQ1Don0AAL0STLZSs4N+6gLEO55pedy7r2cLwS+ZDxPm/2Bw==
+  version "17.0.14"
+  resolved "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz#33b9b94f789a8fedd30a68efdbca4dbb06b61f20"
+  integrity sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==
 
 "@types/node@^13.7.4":
   version "13.13.52"
@@ -3234,9 +3256,9 @@
   integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
 
 "@types/node@^14.14.37":
-  version "14.18.9"
-  resolved "https://registry.npmjs.org/@types/node/-/node-14.18.9.tgz#0e5944eefe2b287391279a19b407aa98bd14436d"
-  integrity sha512-j11XSuRuAlft6vLDEX4RvhqC0KxNxx6QIyMXNb0vHHSNPXTPeiy3algESWmOOIzEtiEL0qiowPU3ewW9hHVa7Q==
+  version "14.18.10"
+  resolved "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz#774f43868964f3cfe4ced1f5417fe15818a4eaea"
+  integrity sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==
 
 "@types/node@^15.0.0":
   version "15.14.9"
@@ -3466,12 +3488,12 @@ abstract-logging@^2.0.0:
   integrity sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==
 
 accepts@~1.3.4:
-  version "1.3.7"
-  resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
-  integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
+  version "1.3.8"
+  resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
   dependencies:
-    mime-types "~2.1.24"
-    negotiator "0.6.2"
+    mime-types "~2.1.34"
+    negotiator "0.6.3"
 
 acorn-globals@^6.0.0:
   version "6.0.0"
@@ -4532,9 +4554,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001286:
-  version "1.0.30001304"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001304.tgz#38af55ed3fc8220cb13e35e6e7309c8c65a05559"
-  integrity sha512-bdsfZd6K6ap87AGqSHJP/s1V+U6Z5lyrcbBu3ovbCCf8cSYpwTtGrCBObMpJqwxfTbLW6YTIdbb1jEeTelcpYQ==
+  version "1.0.30001305"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001305.tgz#02cd8031df07c4fcb117aa2ecc4899122681bd4c"
+  integrity sha512-p7d9YQMji8haf0f+5rbcv9WlQ+N5jMPfRAnUmZRlNxsNeBO3Yr7RYG6M2uTY1h9tCVdlkJg6YNNc4kiAiBLdWA==
 
 canvas@2.8.0:
   version "2.8.0"
@@ -5196,9 +5218,9 @@ convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.6.0,
     safe-buffer "~5.1.1"
 
 cookie@^0.4.0, cookie@~0.4.1:
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
-  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+  version "0.4.2"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -5218,17 +5240,17 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js-compat@^3.16.0, core-js-compat@^3.16.2:
-  version "3.20.3"
-  resolved "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.20.3.tgz#d71f85f94eb5e4bea3407412e549daa083d23bd6"
-  integrity sha512-c8M5h0IkNZ+I92QhIpuSijOxGAcj3lgpsWdkCqmUTZNwidujF4r3pi6x1DCN+Vcs5qTS2XWWMfWSuCqyupX8gw==
+  version "3.21.0"
+  resolved "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.21.0.tgz#bcc86aa5a589cee358e7a7fa0a4979d5a76c3885"
+  integrity sha512-OSXseNPSK2OPJa6GdtkMz/XxeXx8/CJvfhQWTqd6neuUraujcL4jVsjkLQz1OWnax8xVQJnRPe0V2jqNWORA+A==
   dependencies:
     browserslist "^4.19.1"
     semver "7.0.0"
 
 core-js@3, core-js@^3.8.3:
-  version "3.20.3"
-  resolved "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz#c710d0a676e684522f3db4ee84e5e18a9d11d69a"
-  integrity sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==
+  version "3.21.0"
+  resolved "https://registry.npmjs.org/core-js/-/core-js-3.21.0.tgz#f479dbfc3dffb035a0827602dd056839a774aa71"
+  integrity sha512-YUdI3fFu4TF/2WykQ2xzSiTQdldLB4KVuL9WeAy5XONZYt5Cun/fpQvctoKbCgvPhmzADeesTk/j2Rdx77AcKQ==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -6189,9 +6211,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.723, electron-to-chromium@^1.4.17:
-  version "1.4.58"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.58.tgz#cd980b08338210b591c25492857a518fe286b1d4"
-  integrity sha512-7LXwnKyqcEaMFVXOer+2JPfFs1D+ej7yRRrfZoIH1YlLQZ81OvBNwSCBBLtExVkoMQQgOWwO0FbZVge6U/8rhQ==
+  version "1.4.63"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.63.tgz#866db72d1221fda89419dc22669d03833e11625d"
+  integrity sha512-e0PX/LRJPFRU4kzJKLvTobxyFdnANCvcoDCe8XcyTqP58nTWIwdsHvXLIl1RkB39X5yaosLaroMASWB0oIsgCA==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -7569,9 +7591,9 @@ globals@^11.1.0:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^13.6.0, globals@^13.9.0:
-  version "13.12.0"
-  resolved "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz#4d733760304230a0082ed96e21e5c565f898089e"
-  integrity sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==
+  version "13.12.1"
+  resolved "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz#ec206be932e6c77236677127577aa8e50bf1c5cb"
+  integrity sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==
   dependencies:
     type-fest "^0.20.2"
 
@@ -9916,7 +9938,7 @@ mime-db@1.51.0:
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
-mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.34:
   version "2.1.34"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
   integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
@@ -10215,10 +10237,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-negotiator@0.6.2:
-  version "0.6.2"
-  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
-  integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+negotiator@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 neo-async@^2.6.0:
   version "2.6.2"
@@ -11934,10 +11956,10 @@ redux@^4.1.0:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
-regenerate-unicode-properties@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz#54d09c7115e1f53dc2314a974b32c1c344efe326"
-  integrity sha512-3E12UeNSPfjrgwjkR81m5J7Aw/T55Tu7nUyZVQYCKEOs+2dkxEY+DpPtZzO4YruuiPb7NkYLVcyJC4+zCbk5pA==
+regenerate-unicode-properties@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz#7f442732aa7934a3740c779bb9b3340dccc1fb56"
+  integrity sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==
   dependencies:
     regenerate "^1.4.2"
 
@@ -11971,27 +11993,27 @@ regexpp@^3.1.0, regexpp@^3.2.0:
   resolved "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
-regexpu-core@^4.7.1:
-  version "4.8.0"
-  resolved "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.8.0.tgz#e5605ba361b67b1718478501327502f4479a98f0"
-  integrity sha512-1F6bYsoYiz6is+oz70NWur2Vlh9KWtswuRuzJOfeYUrfPX2o8n74AnUVaOGDbUqVGO9fNHu48/pjJO4sNVwsOg==
+regexpu-core@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.0.1.tgz#c531122a7840de743dcf9c83e923b5560323ced3"
+  integrity sha512-CriEZlrKK9VJw/xQGJpQM5rY88BtuL8DM+AEwvcThHilbxiTAy8vq4iJnd2tqq8wLmjbGZzP7ZcKFjbGkmEFrw==
   dependencies:
     regenerate "^1.4.2"
-    regenerate-unicode-properties "^9.0.0"
-    regjsgen "^0.5.2"
-    regjsparser "^0.7.0"
+    regenerate-unicode-properties "^10.0.1"
+    regjsgen "^0.6.0"
+    regjsparser "^0.8.2"
     unicode-match-property-ecmascript "^2.0.0"
     unicode-match-property-value-ecmascript "^2.0.0"
 
-regjsgen@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz#92ff295fb1deecbf6ecdab2543d207e91aa33733"
-  integrity sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==
+regjsgen@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/regjsgen/-/regjsgen-0.6.0.tgz#83414c5354afd7d6627b16af5f10f41c4e71808d"
+  integrity sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==
 
-regjsparser@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.npmjs.org/regjsparser/-/regjsparser-0.7.0.tgz#a6b667b54c885e18b52554cb4960ef71187e9968"
-  integrity sha512-A4pcaORqmNMDVwUjWoTzuhwMGpP+NykpfqAsEgI1FSH/EzC7lrN5TMd+kN8YCovX+jMpu8eaqXgXPCa0g8FQNQ==
+regjsparser@^0.8.2:
+  version "0.8.4"
+  resolved "https://registry.npmjs.org/regjsparser/-/regjsparser-0.8.4.tgz#8a14285ffcc5de78c5b95d62bbf413b6bc132d5f"
+  integrity sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==
   dependencies:
     jsesc "~0.5.0"
 
@@ -12588,9 +12610,9 @@ simple-concat@^1.0.0:
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
 
 simple-get@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz#b45be062435e50d159540b576202ceec40b9c6b3"
-  integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz#cc7ba77cfbe761036fbfce3d021af25fc5584d55"
+  integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
   dependencies:
     decompress-response "^4.2.0"
     once "^1.3.1"
@@ -12838,6 +12860,11 @@ source-map@~0.1.30:
   integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
   dependencies:
     amdefine ">=0.0.4"
+
+sourcemap-codec@1.4.8:
+  version "1.4.8"
+  resolved "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
Small PR to add convenience functions I'm finding helpful while working through demos.

New methods:
* `Series.prototype.toString()`
* `Series.prototype.toArray()`
* `DataFrame.prototype.rename()`

Updates to existing methods:
* Make `type` and `init` optional in `Series.sequence()`
* Cast inputs to required dtypes in `Series.prototype.scatter()`

Also adds support for `cudf::struct_scalar`.