### PR TITLE
[FIX] Make `scope` dispose at the `DeviceBuffer` level

### DIFF
--- a/modules/cudf/src/column.cpp
+++ b/modules/cudf/src/column.cpp
@@ -311,6 +311,20 @@ void Column::dispose(Napi::Env env) {
 void Column::dispose(Napi::CallbackInfo const& info) { dispose(info.Env()); }
 
 Napi::Value Column::disposed(Napi::CallbackInfo const& info) {
+  auto disposed = disposed_;
+  if (!disposed) {
+    if (!data_.IsEmpty() && !data_.Value()->is_empty()) {
+      disposed = false;
+    } else if (!null_mask_.IsEmpty() && !null_mask_.Value()->is_empty()) {
+      disposed = false;
+    } else {
+      disposed = children_.size() == 0 ||
+                 std::all_of(children_.begin(), children_.end(), [&](auto const& child) {
+                   return child.Value()->disposed(info);
+                 });
+    }
+    if (disposed) { dispose(info.Env()); }
+  }
   return Napi::Value::From(info.Env(), disposed_);
 }
 

--- a/modules/cudf/src/data_frame.ts
+++ b/modules/cudf/src/data_frame.ts
@@ -278,9 +278,7 @@ export class DataFrame<T extends TypeMap = any> {
   get types() { return this._accessor.types; }
 
   /** @ignore */
-  asTable() {
-    return new Table({columns: this._accessor.columns.filter(({disposed}) => !disposed)});
-  }
+  asTable() { return new Table({columns: this._accessor.columns}); }
 
   /**
    * Return a string with a tabular representation of the DataFrame, pretty-printed according to the

--- a/modules/cudf/test/cudf-column-tests.ts
+++ b/modules/cudf/test/cudf-column-tests.ts
@@ -72,7 +72,7 @@ test('Column.gather', () => {
 
   const selection = new Column({type: new Int32, data: new Int32Buffer([2, 4, 5, 8])});
 
-  const result = col.gather(selection);
+  const result = col.gather(selection, false);
 
   expect(result.getValue(0)).toBe(2);
   expect(result.getValue(1)).toBe(4);
@@ -85,7 +85,7 @@ test('Column.gather (bad argument)', () => {
 
   const selection = [2, 4, 5];
 
-  expect(() => col.gather(<any>selection)).toThrow();
+  expect(() => col.gather(<any>selection, false)).toThrow();
 });
 
 test('Column null_mask, null_count', () => {


### PR DESCRIPTION
Fixes a bug where buffers for a `Column` returned by `scope()` are disposed if they're shared with a `Column` that is disposed.

Example:

```typescript
import {Series, Uint64, scope} from '@rapidsai/cudf';

const u64s = scope(() => {
  let i32s = Series.sequence({size: 10});
  return i32s.view(new Uint64);
});

u64s.gather([0, 1]) // error! `i32s` and `u64s` share the same `.data` 
                    // DeviceBuffer, but `i32s` was disposed by scope()
```