### PR TITLE
[FIX] Fix return types for different numeric reductions

### DIFF
--- a/modules/cudf/src/series.ts
+++ b/modules/cudf/src/series.ts
@@ -1668,6 +1668,7 @@ function asColumn<T extends DataType>(value: any) {
     if (Array.isArray(data)) {
       return fromArrow<T>(arrow.Vector.from({
         highWaterMark: Infinity,
+        nullValues: [undefined, null, NaN],
         type: value.type ?? inferType(data),
         // Slice `offset` from the Array before converting so
         // we don't write unnecessary values with the Arrow builders.

--- a/modules/cudf/src/series/bool.ts
+++ b/modules/cudf/src/series/bool.ts
@@ -142,17 +142,17 @@ export class Bool8Series extends NumericSeries<Bool8> {
 
   /** @inheritdoc */
   min(skipNulls = true, memoryResource?: MemoryResource) {
-    return super.min(skipNulls, memoryResource) as number;
+    return super.min(skipNulls, memoryResource) as boolean;
   }
 
   /** @inheritdoc */
   max(skipNulls = true, memoryResource?: MemoryResource) {
-    return super.max(skipNulls, memoryResource) as number;
+    return super.max(skipNulls, memoryResource) as boolean;
   }
 
   /** @inheritdoc */
   minmax(skipNulls = true, memoryResource?: MemoryResource) {
-    return super.minmax(skipNulls, memoryResource) as [number, number];
+    return super.minmax(skipNulls, memoryResource) as [boolean, boolean];
   }
 
   /** @inheritdoc */

--- a/modules/cudf/src/series/bool.ts
+++ b/modules/cudf/src/series/bool.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modules/cudf/src/series/float.ts
+++ b/modules/cudf/src/series/float.ts
@@ -334,6 +334,21 @@ abstract class FloatSeries<T extends FloatingPoint> extends NumericSeries<T> {
     return (dropna) ? this._col.nansToNulls(memoryResource).nunique(dropna, memoryResource)
                     : this._col.nunique(dropna, memoryResource);
   }
+
+  /** @inheritdoc */
+  min(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.min(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  max(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.max(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  minmax(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.minmax(skipNulls, memoryResource) as [number, number];
+  }
 }
 
 /**

--- a/modules/cudf/src/series/integral.ts
+++ b/modules/cudf/src/series/integral.ts
@@ -324,6 +324,21 @@ export class Int8Series extends IntSeries<Int8> {
   get data() {
     return new Int8Buffer(this._col.data).subarray(this.offset, this.offset + this.length);
   }
+
+  /** @inheritdoc */
+  min(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.min(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  max(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.max(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  minmax(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.minmax(skipNulls, memoryResource) as [number, number];
+  }
 }
 
 /**
@@ -336,6 +351,21 @@ export class Int16Series extends IntSeries<Int16> {
   get data() {
     return new Int16Buffer(this._col.data).subarray(this.offset, this.offset + this.length);
   }
+
+  /** @inheritdoc */
+  min(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.min(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  max(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.max(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  minmax(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.minmax(skipNulls, memoryResource) as [number, number];
+  }
 }
 
 /**
@@ -347,6 +377,21 @@ export class Int32Series extends IntSeries<Int32> {
    */
   get data() {
     return new Int32Buffer(this._col.data).subarray(this.offset, this.offset + this.length);
+  }
+
+  /** @inheritdoc */
+  min(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.min(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  max(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.max(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  minmax(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.minmax(skipNulls, memoryResource) as [number, number];
   }
 }
 
@@ -363,6 +408,21 @@ export class Int64Series extends IntSeries<Int64> {
   get data() {
     return new Int64Buffer(this._col.data).subarray(this.offset, this.offset + this.length);
   }
+
+  /** @inheritdoc */
+  min(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.min(skipNulls, memoryResource) as bigint;
+  }
+
+  /** @inheritdoc */
+  max(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.max(skipNulls, memoryResource) as bigint;
+  }
+
+  /** @inheritdoc */
+  minmax(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.minmax(skipNulls, memoryResource) as [bigint, bigint];
+  }
 }
 
 /**
@@ -374,6 +434,21 @@ export class Uint8Series extends IntSeries<Uint8> {
    */
   get data() {
     return new Uint8Buffer(this._col.data).subarray(this.offset, this.offset + this.length);
+  }
+
+  /** @inheritdoc */
+  min(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.min(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  max(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.max(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  minmax(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.minmax(skipNulls, memoryResource) as [number, number];
   }
 }
 
@@ -387,6 +462,21 @@ export class Uint16Series extends IntSeries<Uint16> {
   get data() {
     return new Uint16Buffer(this._col.data).subarray(this.offset, this.offset + this.length);
   }
+
+  /** @inheritdoc */
+  min(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.min(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  max(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.max(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  minmax(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.minmax(skipNulls, memoryResource) as [number, number];
+  }
 }
 
 /**
@@ -398,6 +488,21 @@ export class Uint32Series extends IntSeries<Uint32> {
    */
   get data() {
     return new Uint32Buffer(this._col.data).subarray(this.offset, this.offset + this.length);
+  }
+
+  /** @inheritdoc */
+  min(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.min(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  max(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.max(skipNulls, memoryResource) as number;
+  }
+
+  /** @inheritdoc */
+  minmax(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.minmax(skipNulls, memoryResource) as [number, number];
   }
 }
 
@@ -413,5 +518,20 @@ export class Uint64Series extends IntSeries<Uint64> {
    */
   get data() {
     return new Uint64Buffer(this._col.data).subarray(this.offset, this.offset + this.length);
+  }
+
+  /** @inheritdoc */
+  min(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.min(skipNulls, memoryResource) as bigint;
+  }
+
+  /** @inheritdoc */
+  max(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.max(skipNulls, memoryResource) as bigint;
+  }
+
+  /** @inheritdoc */
+  minmax(skipNulls = true, memoryResource?: MemoryResource) {
+    return super.minmax(skipNulls, memoryResource) as [bigint, bigint];
   }
 }

--- a/modules/cudf/src/series/numeric.ts
+++ b/modules/cudf/src/series/numeric.ts
@@ -171,17 +171,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   add(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   add(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  add<R extends Numeric>(rhs: Scalar<R>, memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  add<R extends Numeric>(rhs: NumericSeries<R>,
-                         memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  add<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>, memoryResource?: MemoryResource) {
+  add<R extends Scalar<Numeric>>(rhs: R,
+                                 memoryResource?: MemoryResource): Series<CommonType<T, R['type']>>;
+  add<R extends Series<Numeric>>(rhs: R,
+                                 memoryResource?: MemoryResource): Series<CommonType<T, R['type']>>;
+  add(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.add(rhs, memoryResource));
       case 'number': return Series.new(this._col.add(rhs, memoryResource));
       default: break;
     }
     return rhs instanceof Scalar ? Series.new(this._col.add(rhs, memoryResource))
-                                 : Series.new(this._col.add(rhs._col as Column<R>, memoryResource));
+                                 : Series.new(this._col.add(rhs._col, memoryResource));
   }
 
   /**
@@ -203,17 +204,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   sub(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   sub(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  sub<R extends Numeric>(rhs: Scalar<R>, memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  sub<R extends Numeric>(rhs: NumericSeries<R>,
-                         memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  sub<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>, memoryResource?: MemoryResource) {
+  sub<R extends Scalar<Numeric>>(rhs: R,
+                                 memoryResource?: MemoryResource): Series<CommonType<T, R['type']>>;
+  sub<R extends Series<Numeric>>(rhs: R,
+                                 memoryResource?: MemoryResource): Series<CommonType<T, R['type']>>;
+  sub(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.sub(rhs, memoryResource));
       case 'number': return Series.new(this._col.sub(rhs, memoryResource));
       default: break;
     }
     return rhs instanceof Scalar ? Series.new(this._col.sub(rhs, memoryResource))
-                                 : Series.new(this._col.sub(rhs._col as Column<R>, memoryResource));
+                                 : Series.new(this._col.sub(rhs._col, memoryResource));
   }
 
   /**
@@ -235,17 +237,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   mul(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   mul(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  mul<R extends Numeric>(rhs: Scalar<R>, memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  mul<R extends Numeric>(rhs: NumericSeries<R>,
-                         memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  mul<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>, memoryResource?: MemoryResource) {
+  mul<R extends Scalar<Numeric>>(rhs: R,
+                                 memoryResource?: MemoryResource): Series<CommonType<T, R['type']>>;
+  mul<R extends Series<Numeric>>(rhs: R,
+                                 memoryResource?: MemoryResource): Series<CommonType<T, R['type']>>;
+  mul(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.mul(rhs, memoryResource));
       case 'number': return Series.new(this._col.mul(rhs, memoryResource));
       default: break;
     }
     return rhs instanceof Scalar ? Series.new(this._col.mul(rhs, memoryResource))
-                                 : Series.new(this._col.mul(rhs._col as Column<R>, memoryResource));
+                                 : Series.new(this._col.mul(rhs._col, memoryResource));
   }
 
   /**
@@ -267,17 +270,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   div(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   div(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  div<R extends Numeric>(rhs: Scalar<R>, memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  div<R extends Numeric>(rhs: NumericSeries<R>,
-                         memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  div<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>, memoryResource?: MemoryResource) {
+  div<R extends Scalar<Numeric>>(rhs: R,
+                                 memoryResource?: MemoryResource): Series<CommonType<T, R['type']>>;
+  div<R extends Series<Numeric>>(rhs: R,
+                                 memoryResource?: MemoryResource): Series<CommonType<T, R['type']>>;
+  div(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.div(rhs, memoryResource));
       case 'number': return Series.new(this._col.div(rhs, memoryResource));
       default: break;
     }
     return rhs instanceof Scalar ? Series.new(this._col.div(rhs, memoryResource))
-                                 : Series.new(this._col.div(rhs._col as Column<R>, memoryResource));
+                                 : Series.new(this._col.div(rhs._col, memoryResource));
   }
 
   /**
@@ -299,20 +303,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   trueDiv(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   trueDiv(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  trueDiv<R extends Numeric>(rhs: Scalar<R>,
-                             memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  trueDiv<R extends Numeric>(rhs: NumericSeries<R>,
-                             memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  trueDiv<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>,
-                             memoryResource?: MemoryResource) {
+  trueDiv<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  trueDiv<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  trueDiv(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.trueDiv(rhs, memoryResource));
       case 'number': return Series.new(this._col.trueDiv(rhs, memoryResource));
       default: break;
     }
-    return rhs instanceof Scalar
-             ? Series.new(this._col.trueDiv(rhs, memoryResource))
-             : Series.new(this._col.trueDiv(rhs._col as Column<R>, memoryResource));
+    return rhs instanceof Scalar ? Series.new(this._col.trueDiv(rhs, memoryResource))
+                                 : Series.new(this._col.trueDiv(rhs._col, memoryResource));
   }
 
   /**
@@ -334,20 +336,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   floorDiv(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   floorDiv(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  floorDiv<R extends Numeric>(rhs: Scalar<R>,
-                              memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  floorDiv<R extends Numeric>(rhs: NumericSeries<R>,
-                              memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  floorDiv<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>,
-                              memoryResource?: MemoryResource) {
+  floorDiv<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  floorDiv<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  floorDiv(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.floorDiv(rhs, memoryResource));
       case 'number': return Series.new(this._col.floorDiv(rhs, memoryResource));
       default: break;
     }
-    return rhs instanceof Scalar
-             ? Series.new(this._col.floorDiv(rhs, memoryResource))
-             : Series.new(this._col.floorDiv(rhs._col as Column<R>, memoryResource));
+    return rhs instanceof Scalar ? Series.new(this._col.floorDiv(rhs, memoryResource))
+                                 : Series.new(this._col.floorDiv(rhs._col, memoryResource));
   }
 
   /**
@@ -369,17 +369,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   mod(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   mod(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  mod<R extends Numeric>(rhs: Scalar<R>, memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  mod<R extends Numeric>(rhs: NumericSeries<R>,
-                         memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  mod<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>, memoryResource?: MemoryResource) {
+  mod<R extends Scalar<Numeric>>(rhs: R,
+                                 memoryResource?: MemoryResource): Series<CommonType<T, R['type']>>;
+  mod<R extends Series<Numeric>>(rhs: R,
+                                 memoryResource?: MemoryResource): Series<CommonType<T, R['type']>>;
+  mod(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.mod(rhs, memoryResource));
       case 'number': return Series.new(this._col.mod(rhs, memoryResource));
       default: break;
     }
     return rhs instanceof Scalar ? Series.new(this._col.mod(rhs, memoryResource))
-                                 : Series.new(this._col.mod(rhs._col as Column<R>, memoryResource));
+                                 : Series.new(this._col.mod(rhs._col, memoryResource));
   }
 
   /**
@@ -401,17 +402,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   pow(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   pow(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  pow<R extends Numeric>(rhs: Scalar<R>, memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  pow<R extends Numeric>(rhs: NumericSeries<R>,
-                         memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  pow<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>, memoryResource?: MemoryResource) {
+  pow<R extends Scalar<Numeric>>(rhs: R,
+                                 memoryResource?: MemoryResource): Series<CommonType<T, R['type']>>;
+  pow<R extends Series<Numeric>>(rhs: R,
+                                 memoryResource?: MemoryResource): Series<CommonType<T, R['type']>>;
+  pow(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.pow(rhs, memoryResource));
       case 'number': return Series.new(this._col.pow(rhs, memoryResource));
       default: break;
     }
     return rhs instanceof Scalar ? Series.new(this._col.pow(rhs, memoryResource))
-                                 : Series.new(this._col.pow(rhs._col as Column<R>, memoryResource));
+                                 : Series.new(this._col.pow(rhs._col, memoryResource));
   }
 
   /**
@@ -433,16 +435,16 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   eq(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   eq(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
-  eq<R extends Numeric>(rhs: Scalar<R>, memoryResource?: MemoryResource): Series<Bool8>;
-  eq<R extends Numeric>(rhs: NumericSeries<R>, memoryResource?: MemoryResource): Series<Bool8>;
-  eq<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>, memoryResource?: MemoryResource) {
+  eq<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  eq<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  eq(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.eq(rhs, memoryResource));
       case 'number': return Series.new(this._col.eq(rhs, memoryResource));
       default: break;
     }
     return rhs instanceof Scalar ? Series.new(this._col.eq(rhs, memoryResource))
-                                 : Series.new(this._col.eq(rhs._col as Column<R>, memoryResource));
+                                 : Series.new(this._col.eq(rhs._col, memoryResource));
   }
 
   /**
@@ -464,16 +466,16 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   ne(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   ne(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
-  ne<R extends Numeric>(rhs: Scalar<R>, memoryResource?: MemoryResource): Series<Bool8>;
-  ne<R extends Numeric>(rhs: NumericSeries<R>, memoryResource?: MemoryResource): Series<Bool8>;
-  ne<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>, memoryResource?: MemoryResource) {
+  ne<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  ne<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  ne(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.ne(rhs, memoryResource));
       case 'number': return Series.new(this._col.ne(rhs, memoryResource));
       default: break;
     }
     return rhs instanceof Scalar ? Series.new(this._col.ne(rhs, memoryResource))
-                                 : Series.new(this._col.ne(rhs._col as Column<R>, memoryResource));
+                                 : Series.new(this._col.ne(rhs._col, memoryResource));
   }
 
   /**
@@ -495,16 +497,16 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   lt(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   lt(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
-  lt<R extends Numeric>(rhs: Scalar<R>, memoryResource?: MemoryResource): Series<Bool8>;
-  lt<R extends Numeric>(rhs: NumericSeries<R>, memoryResource?: MemoryResource): Series<Bool8>;
-  lt<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>, memoryResource?: MemoryResource) {
+  lt<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  lt<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  lt(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.lt(rhs, memoryResource));
       case 'number': return Series.new(this._col.lt(rhs, memoryResource));
       default: break;
     }
     return rhs instanceof Scalar ? Series.new(this._col.lt(rhs, memoryResource))
-                                 : Series.new(this._col.lt(rhs._col as Column<R>, memoryResource));
+                                 : Series.new(this._col.lt(rhs._col, memoryResource));
   }
 
   /**
@@ -526,16 +528,16 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   le(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   le(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
-  le<R extends Numeric>(rhs: Scalar<R>, memoryResource?: MemoryResource): Series<Bool8>;
-  le<R extends Numeric>(rhs: NumericSeries<R>, memoryResource?: MemoryResource): Series<Bool8>;
-  le<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>, memoryResource?: MemoryResource) {
+  le<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  le<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  le(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.le(rhs, memoryResource));
       case 'number': return Series.new(this._col.le(rhs, memoryResource));
       default: break;
     }
     return rhs instanceof Scalar ? Series.new(this._col.le(rhs, memoryResource))
-                                 : Series.new(this._col.le(rhs._col as Column<R>, memoryResource));
+                                 : Series.new(this._col.le(rhs._col, memoryResource));
   }
 
   /**
@@ -557,16 +559,16 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   gt(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   gt(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
-  gt<R extends Numeric>(rhs: Scalar<R>, memoryResource?: MemoryResource): Series<Bool8>;
-  gt<R extends Numeric>(rhs: NumericSeries<R>, memoryResource?: MemoryResource): Series<Bool8>;
-  gt<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>, memoryResource?: MemoryResource) {
+  gt<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  gt<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  gt(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.gt(rhs, memoryResource));
       case 'number': return Series.new(this._col.gt(rhs, memoryResource));
       default: break;
     }
     return rhs instanceof Scalar ? Series.new(this._col.gt(rhs, memoryResource))
-                                 : Series.new(this._col.gt(rhs._col as Column<R>, memoryResource));
+                                 : Series.new(this._col.gt(rhs._col, memoryResource));
   }
 
   /**
@@ -588,16 +590,16 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   ge(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   ge(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
-  ge<R extends Numeric>(rhs: Scalar<R>, memoryResource?: MemoryResource): Series<Bool8>;
-  ge<R extends Numeric>(rhs: NumericSeries<R>, memoryResource?: MemoryResource): Series<Bool8>;
-  ge<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>, memoryResource?: MemoryResource) {
+  ge<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  ge<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  ge(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.ge(rhs, memoryResource));
       case 'number': return Series.new(this._col.ge(rhs, memoryResource));
       default: break;
     }
     return rhs instanceof Scalar ? Series.new(this._col.ge(rhs, memoryResource))
-                                 : Series.new(this._col.ge(rhs._col as Column<R>, memoryResource));
+                                 : Series.new(this._col.ge(rhs._col, memoryResource));
   }
 
   /**
@@ -620,20 +622,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   logicalAnd(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   logicalAnd(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  logicalAnd<R extends Numeric>(rhs: Scalar<R>,
-                                memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  logicalAnd<R extends Numeric>(rhs: NumericSeries<R>,
-                                memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  logicalAnd<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>,
-                                memoryResource?: MemoryResource) {
+  logicalAnd<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  logicalAnd<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  logicalAnd(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.logicalAnd(rhs, memoryResource));
       case 'number': return Series.new(this._col.logicalAnd(rhs, memoryResource));
       default: break;
     }
-    return rhs instanceof Scalar
-             ? Series.new(this._col.logicalAnd(rhs, memoryResource))
-             : Series.new(this._col.logicalAnd(rhs._col as Column<R>, memoryResource));
+    return rhs instanceof Scalar ? Series.new(this._col.logicalAnd(rhs, memoryResource))
+                                 : Series.new(this._col.logicalAnd(rhs._col, memoryResource));
   }
 
   /**
@@ -656,20 +656,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   logicalOr(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   logicalOr(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  logicalOr<R extends Numeric>(rhs: Scalar<R>,
-                               memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  logicalOr<R extends Numeric>(rhs: NumericSeries<R>,
-                               memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  logicalOr<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>,
-                               memoryResource?: MemoryResource) {
+  logicalOr<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  logicalOr<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  logicalOr(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.logicalOr(rhs, memoryResource));
       case 'number': return Series.new(this._col.logicalOr(rhs, memoryResource));
       default: break;
     }
-    return rhs instanceof Scalar
-             ? Series.new(this._col.logicalOr(rhs, memoryResource))
-             : Series.new(this._col.logicalOr(rhs._col as Column<R>, memoryResource));
+    return rhs instanceof Scalar ? Series.new(this._col.logicalOr(rhs, memoryResource))
+                                 : Series.new(this._col.logicalOr(rhs._col, memoryResource));
   }
 
   /**
@@ -691,20 +689,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   logBase(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   logBase(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  logBase<R extends Numeric>(rhs: Scalar<R>,
-                             memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  logBase<R extends Numeric>(rhs: NumericSeries<R>,
-                             memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  logBase<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>,
-                             memoryResource?: MemoryResource) {
+  logBase<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  logBase<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  logBase(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.logBase(rhs, memoryResource));
       case 'number': return Series.new(this._col.logBase(rhs, memoryResource));
       default: break;
     }
-    return rhs instanceof Scalar
-             ? Series.new(this._col.logBase(rhs, memoryResource))
-             : Series.new(this._col.logBase(rhs._col as Column<R>, memoryResource));
+    return rhs instanceof Scalar ? Series.new(this._col.logBase(rhs, memoryResource))
+                                 : Series.new(this._col.logBase(rhs._col, memoryResource));
   }
 
   /**
@@ -729,20 +725,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   atan2(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   atan2(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  atan2<R extends Numeric>(rhs: Scalar<R>,
-                           memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  atan2<R extends Numeric>(rhs: NumericSeries<R>,
-                           memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  atan2<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>,
-                           memoryResource?: MemoryResource) {
+  atan2<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  atan2<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  atan2(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.atan2(rhs, memoryResource));
       case 'number': return Series.new(this._col.atan2(rhs, memoryResource));
       default: break;
     }
-    return rhs instanceof Scalar
-             ? Series.new(this._col.atan2(rhs, memoryResource))
-             : Series.new(this._col.atan2(rhs._col as Column<R>, memoryResource));
+    return rhs instanceof Scalar ? Series.new(this._col.atan2(rhs, memoryResource))
+                                 : Series.new(this._col.atan2(rhs._col, memoryResource));
   }
 
   /**
@@ -765,19 +759,16 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   nullEquals(rhs: bigint, memoryResource?: MemoryResource): Series<Bool8>;
   nullEquals(rhs: number, memoryResource?: MemoryResource): Series<Bool8>;
-  nullEquals<R extends Numeric>(rhs: Scalar<R>, memoryResource?: MemoryResource): Series<Bool8>;
-  nullEquals<R extends Numeric>(rhs: NumericSeries<R>,
-                                memoryResource?: MemoryResource): Series<Bool8>;
-  nullEquals<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>,
-                                memoryResource?: MemoryResource) {
+  nullEquals<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  nullEquals<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource): Series<Bool8>;
+  nullEquals(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.nullEquals(rhs, memoryResource));
       case 'number': return Series.new(this._col.nullEquals(rhs, memoryResource));
       default: break;
     }
-    return rhs instanceof Scalar
-             ? Series.new(this._col.nullEquals(rhs, memoryResource))
-             : Series.new(this._col.nullEquals(rhs._col as Column<R>, memoryResource));
+    return rhs instanceof Scalar ? Series.new(this._col.nullEquals(rhs, memoryResource))
+                                 : Series.new(this._col.nullEquals(rhs._col, memoryResource));
   }
 
   /**
@@ -799,20 +790,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   nullMax(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   nullMax(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  nullMax<R extends Numeric>(rhs: Scalar<R>,
-                             memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  nullMax<R extends Numeric>(rhs: NumericSeries<R>,
-                             memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  nullMax<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>,
-                             memoryResource?: MemoryResource) {
+  nullMax<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  nullMax<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  nullMax(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.nullMax(rhs, memoryResource));
       case 'number': return Series.new(this._col.nullMax(rhs, memoryResource));
       default: break;
     }
-    return rhs instanceof Scalar
-             ? Series.new(this._col.nullMax(rhs, memoryResource))
-             : Series.new(this._col.nullMax(rhs._col as Column<R>, memoryResource));
+    return rhs instanceof Scalar ? Series.new(this._col.nullMax(rhs, memoryResource))
+                                 : Series.new(this._col.nullMax(rhs._col, memoryResource));
   }
 
   /**
@@ -834,20 +823,18 @@ export abstract class NumericSeries<T extends Numeric> extends Series<T> {
    */
   nullMin(rhs: bigint, memoryResource?: MemoryResource): Int64Series;
   nullMin(rhs: number, memoryResource?: MemoryResource): Float64Series;
-  nullMin<R extends Numeric>(rhs: Scalar<R>,
-                             memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  nullMin<R extends Numeric>(rhs: NumericSeries<R>,
-                             memoryResource?: MemoryResource): Series<CommonType<T, R>>;
-  nullMin<R extends Numeric>(rhs: bigint|number|Scalar<R>|Series<R>,
-                             memoryResource?: MemoryResource) {
+  nullMin<R extends Scalar<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  nullMin<R extends Series<Numeric>>(rhs: R, memoryResource?: MemoryResource):
+    Series<CommonType<T, R['type']>>;
+  nullMin(rhs: any, memoryResource?: MemoryResource) {
     switch (typeof rhs) {
       case 'bigint': return Series.new(this._col.nullMin(rhs, memoryResource));
       case 'number': return Series.new(this._col.nullMin(rhs, memoryResource));
       default: break;
     }
-    return rhs instanceof Scalar
-             ? Series.new(this._col.nullMin(rhs, memoryResource))
-             : Series.new(this._col.nullMin(rhs._col as Column<R>, memoryResource));
+    return rhs instanceof Scalar ? Series.new(this._col.nullMin(rhs, memoryResource))
+                                 : Series.new(this._col.nullMin(rhs._col, memoryResource));
   }
 
   /**

--- a/modules/cudf/test/cudf-data-frame-tests.ts
+++ b/modules/cudf/test/cudf-data-frame-tests.ts
@@ -339,7 +339,7 @@ test('DataFrame groupBy (single)', () => {
   expect(out instanceof GroupBySingle).toBe(true);
 });
 
-test('DataFrame groupBy (single)', () => {
+test('DataFrame groupBy (multiple)', () => {
   const a   = Series.new({type: new Int32, data: [1, 2, 3, 1, 2, 2, 1, 3, 3, 2]});
   const aa  = Series.new({type: new Int32, data: [1, 2, 3, 1, 2, 2, 1, 3, 3, 2]});
   const b   = Series.new({type: new Float32, data: [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]});

--- a/modules/cudf/test/series/reduce/max-tests.ts
+++ b/modules/cudf/test/series/reduce/max-tests.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION.
+// Copyright (c) 2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modules/cudf/test/series/reduce/max-tests.ts
+++ b/modules/cudf/test/series/reduce/max-tests.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import '../../jest-extensions';
+
+import {setDefaultAllocator} from '@rapidsai/cuda';
+import {
+  Bool8,
+  Float32,
+  Float64,
+  Int16,
+  Int32,
+  Int64,
+  Int8,
+  Series,
+  Uint16,
+  Uint32,
+  Uint64,
+  Uint8
+} from '@rapidsai/cudf';
+import {DeviceBuffer} from '@rapidsai/rmm';
+
+setDefaultAllocator((byteLength: number) => new DeviceBuffer(byteLength));
+
+const numbers        = [4, 2, null, 5, 1, 1];
+const float_with_NaN = [4, 2, NaN, 5, 1, 1];
+const bools          = [true, false, null, false, true];
+const bigints        = [4n, 2n, null, 5n, 1n, 1n];
+
+function testNumberAny<T extends Int8|Int16|Int32|Uint8|Uint16|Uint32|Float32|Float64>(
+  type: T, data: (T['scalarType']|null)[], skipNulls = true) {
+  expect(Series.new({type, data}).max(skipNulls)).toEqual(5);
+}
+
+function testBigIntAny<T extends Int64|Uint64>(
+  type: T, data: (T['scalarType']|null)[], skipNulls = true) {
+  expect(Series.new({type, data}).max(skipNulls)).toEqual(5n);
+}
+
+function testBooleanAny<T extends Bool8>(
+  type: T, data: (T['scalarType']|null)[], skipNulls = true) {
+  expect(Series.new({type, data}).max(skipNulls)).toEqual(true);
+}
+
+describe.each([[true], [false]])('Series.max(skipNulls=%p)', (skipNulls) => {
+  test('Int8', () => { testNumberAny(new Int8, numbers, skipNulls); });
+  test('Int16', () => { testNumberAny(new Int16, numbers, skipNulls); });
+  test('Int32', () => { testNumberAny(new Int32, numbers, skipNulls); });
+  test('Int64', () => { testBigIntAny(new Int64, bigints, skipNulls); });
+  test('Uint8', () => { testNumberAny(new Uint8, numbers, skipNulls); });
+  test('Uint16', () => { testNumberAny(new Uint16, numbers, skipNulls); });
+  test('Uint32', () => { testNumberAny(new Uint32, numbers, skipNulls); });
+  test('Uint64', () => { testBigIntAny(new Uint64, bigints, skipNulls); });
+  test('Float32', () => { testNumberAny(new Float32, numbers, skipNulls); });
+  test('Float64', () => { testNumberAny(new Float64, numbers, skipNulls); });
+  test('Bool8', () => { testBooleanAny(new Bool8, bools, skipNulls); });
+  test('Float32-nan', () => { testNumberAny(new Float32, float_with_NaN, skipNulls); });
+  test('Float64-nan', () => { testNumberAny(new Float64, float_with_NaN, skipNulls); });
+});

--- a/modules/cudf/test/series/reduce/min-tests.ts
+++ b/modules/cudf/test/series/reduce/min-tests.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION.
+// Copyright (c) 2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modules/cudf/test/series/reduce/min-tests.ts
+++ b/modules/cudf/test/series/reduce/min-tests.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import '../../jest-extensions';
+
+import {setDefaultAllocator} from '@rapidsai/cuda';
+import {
+  Bool8,
+  Float32,
+  Float64,
+  Int16,
+  Int32,
+  Int64,
+  Int8,
+  Series,
+  Uint16,
+  Uint32,
+  Uint64,
+  Uint8
+} from '@rapidsai/cudf';
+import {DeviceBuffer} from '@rapidsai/rmm';
+
+setDefaultAllocator((byteLength: number) => new DeviceBuffer(byteLength));
+
+const numbers        = [4, 2, null, 5, 1, 1];
+const float_with_NaN = [4, 2, NaN, 5, 1, 1];
+const bools          = [true, false, null, false, true];
+const bigints        = [4n, 2n, null, 5n, 1n, 1n];
+
+function testNumberAny<T extends Int8|Int16|Int32|Uint8|Uint16|Uint32|Float32|Float64>(
+  type: T, data: (T['scalarType']|null)[], skipNulls = true) {
+  expect(Series.new({type, data}).min(skipNulls)).toEqual(1);
+}
+
+function testBigIntAny<T extends Int64|Uint64>(
+  type: T, data: (T['scalarType']|null)[], skipNulls = true) {
+  expect(Series.new({type, data}).min(skipNulls)).toEqual(1n);
+}
+
+function testBooleanAny<T extends Bool8>(
+  type: T, data: (T['scalarType']|null)[], skipNulls = true) {
+  expect(Series.new({type, data}).min(skipNulls)).toEqual(false);
+}
+
+describe.each([[true], [false]])('Series.min(skipNulls=%p)', (skipNulls) => {
+  test('Int8', () => { testNumberAny(new Int8, numbers, skipNulls); });
+  test('Int16', () => { testNumberAny(new Int16, numbers, skipNulls); });
+  test('Int32', () => { testNumberAny(new Int32, numbers, skipNulls); });
+  test('Int64', () => { testBigIntAny(new Int64, bigints, skipNulls); });
+  test('Uint8', () => { testNumberAny(new Uint8, numbers, skipNulls); });
+  test('Uint16', () => { testNumberAny(new Uint16, numbers, skipNulls); });
+  test('Uint32', () => { testNumberAny(new Uint32, numbers, skipNulls); });
+  test('Uint64', () => { testBigIntAny(new Uint64, bigints, skipNulls); });
+  test('Float32', () => { testNumberAny(new Float32, numbers, skipNulls); });
+  test('Float64', () => { testNumberAny(new Float64, numbers, skipNulls); });
+  test('Bool8', () => { testBooleanAny(new Bool8, bools, skipNulls); });
+  test('Float32-nan', () => { testNumberAny(new Float32, float_with_NaN, skipNulls); });
+  test('Float64-nan', () => { testNumberAny(new Float64, float_with_NaN, skipNulls); });
+});

--- a/modules/cudf/test/series/reduce/minmax-tests.ts
+++ b/modules/cudf/test/series/reduce/minmax-tests.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION.
+// Copyright (c) 2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modules/cudf/test/series/reduce/minmax-tests.ts
+++ b/modules/cudf/test/series/reduce/minmax-tests.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import '../../jest-extensions';
+
+import {setDefaultAllocator} from '@rapidsai/cuda';
+import {
+  Bool8,
+  Float32,
+  Float64,
+  Int16,
+  Int32,
+  Int64,
+  Int8,
+  Series,
+  Uint16,
+  Uint32,
+  Uint64,
+  Uint8
+} from '@rapidsai/cudf';
+import {DeviceBuffer} from '@rapidsai/rmm';
+
+setDefaultAllocator((byteLength: number) => new DeviceBuffer(byteLength));
+
+const numbers        = [4, 2, null, 5, 1, 1];
+const float_with_NaN = [4, 2, NaN, 5, 1, 1];
+const bools          = [true, false, null, false, true];
+const bigints        = [4n, 2n, null, 5n, 1n, 1n];
+
+function testNumberAny<T extends Int8|Int16|Int32|Uint8|Uint16|Uint32|Float32|Float64>(
+  type: T, data: (T['scalarType']|null)[], skipNulls = true) {
+  expect(Series.new({type, data}).minmax(skipNulls)).toEqual([1, 5]);
+}
+
+function testBigIntAny<T extends Int64|Uint64>(
+  type: T, data: (T['scalarType']|null)[], skipNulls = true) {
+  expect(Series.new({type, data}).minmax(skipNulls)).toEqual([1n, 5n]);
+}
+
+function testBooleanAny<T extends Bool8>(
+  type: T, data: (T['scalarType']|null)[], skipNulls = true) {
+  expect(Series.new({type, data}).minmax(skipNulls)).toEqual([false, true]);
+}
+
+describe.each([[true], [false]])('Series.minmax(skipNulls=%p)', (skipNulls) => {
+  test('Int8', () => { testNumberAny(new Int8, numbers, skipNulls); });
+  test('Int16', () => { testNumberAny(new Int16, numbers, skipNulls); });
+  test('Int32', () => { testNumberAny(new Int32, numbers, skipNulls); });
+  test('Int64', () => { testBigIntAny(new Int64, bigints, skipNulls); });
+  test('Uint8', () => { testNumberAny(new Uint8, numbers, skipNulls); });
+  test('Uint16', () => { testNumberAny(new Uint16, numbers, skipNulls); });
+  test('Uint32', () => { testNumberAny(new Uint32, numbers, skipNulls); });
+  test('Uint64', () => { testBigIntAny(new Uint64, bigints, skipNulls); });
+  test('Float32', () => { testNumberAny(new Float32, numbers, skipNulls); });
+  test('Float64', () => { testNumberAny(new Float64, numbers, skipNulls); });
+  test('Bool8', () => { testBooleanAny(new Bool8, bools, skipNulls); });
+  test('Float32-nan', () => { testNumberAny(new Float32, float_with_NaN, skipNulls); });
+  test('Float64-nan', () => { testNumberAny(new Float64, float_with_NaN, skipNulls); });
+});


### PR DESCRIPTION
Small PR to fix the return types of `min()`, `max()`, and `minmax()`.