### PR TITLE
Add DedupedEdgesGraph

### DIFF
--- a/modules/cugraph/src/index.ts
+++ b/modules/cugraph/src/index.ts
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 export * as addon from './addon';
-export {Graph} from './graph';
+export {DedupedEdgesGraph, Graph} from './graph';
 export {hypergraph, hypergraphDirect} from './hypergraph';
 export {renumberEdges, renumberNodes} from './renumber';

--- a/modules/cugraph/test/community/spectral-clustering-tests.ts
+++ b/modules/cugraph/test/community/spectral-clustering-tests.ts
@@ -14,7 +14,7 @@
 
 import {setDefaultAllocator} from '@rapidsai/cuda';
 import {DataFrame, Series} from '@rapidsai/cudf';
-import {Graph} from '@rapidsai/cugraph';
+import {DedupedEdgesGraph} from '@rapidsai/cugraph';
 import {CudaMemoryResource, DeviceBuffer} from '@rapidsai/rmm';
 
 const mr = new CudaMemoryResource();
@@ -24,10 +24,10 @@ setDefaultAllocator((byteLength: number) => new DeviceBuffer(byteLength, mr));
 test.each([
   {type: 'balanced_cut', num_clusters: 2, expected: [1, 0, 0]},
   {type: 'modularity_maximization', num_clusters: 2, expected: [0, 1, 0]},
-])(`Graph.computeClusters (%j)`, ({type, num_clusters, expected}: any) => {
+])(`DedupedEdgesGraph.computeClusters (%j)`, ({type, num_clusters, expected}: any) => {
   const src   = Series.new(new Int32Array([0, 0, 0, 1]));
   const dst   = Series.new(new Int32Array([1, 1, 1, 2]));
-  const graph = Graph.fromEdgeList(src, dst);
+  const graph = DedupedEdgesGraph.fromEdgeList(src, dst);
   expect(graph.computeClusters({type, num_clusters}).toString())
     .toEqual(new DataFrame({
                vertex: Series.new(new Int32Array([0, 1, 2])),
@@ -42,10 +42,11 @@ test.each([
   {type: 'edge_cut', clusterType: 'modularity_maximization', num_clusters: 2, expected: 2},
   {type: 'ratio_cut', clusterType: 'modularity_maximization', num_clusters: 2, expected: 2.5},
   {type: 'modularity', clusterType: 'modularity_maximization', num_clusters: 2, expected: -.625},
-])(`Graph.analyzeClustering (%j)`, ({type, clusterType, num_clusters, expected}: any) => {
-  const src     = Series.new(new Int32Array([0, 0, 0, 1]));
-  const dst     = Series.new(new Int32Array([1, 1, 1, 2]));
-  const graph   = Graph.fromEdgeList(src, dst);
-  const cluster = graph.computeClusters({type: clusterType, num_clusters}).get('cluster');
-  expect(graph.analyzeClustering({type, num_clusters, cluster})).toEqual(expected);
-});
+])(`DedupedEdgesGraph.analyzeClustering (%j)`,
+   ({type, clusterType, num_clusters, expected}: any) => {
+     const src     = Series.new(new Int32Array([0, 0, 0, 1]));
+     const dst     = Series.new(new Int32Array([1, 1, 1, 2]));
+     const graph   = DedupedEdgesGraph.fromEdgeList(src, dst);
+     const cluster = graph.computeClusters({type: clusterType, num_clusters}).get('cluster');
+     expect(graph.analyzeClustering({type, num_clusters, cluster})).toEqual(expected);
+   });


### PR DESCRIPTION
Adds a `DedupedEdgesGraph` subclass of `Graph` that automatically removes duplicate edges. Spectral clustering algorithms that assume deduped edges are moved as well.

cc @trxcllnt once you are :+1: on the API, I'd like to flesh out the graph.ts tests more, they are currently a bit sparse in general.

