### PR TITLE
[FIX] `npm pack` then `npm install llnode` due to npm changes

### DIFF
--- a/dev/dockerfiles/devel/main.Dockerfile
+++ b/dev/dockerfiles/devel/main.Dockerfile
@@ -285,7 +285,9 @@ deb-src  http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -c
  && (git remote add origin https://github.com/trxcllnt/llnode.git 2>/dev/null || true) \
  && git fetch origin use-llvm-project-monorepo && git checkout use-llvm-project-monorepo \
  && cd / \
- && npm install --global --unsafe-perm --no-audit --no-fund /usr/local/lib/llnode \
+ && npm pack --pack-destination /usr/local/lib/llnode /usr/local/lib/llnode \
+ && npm install --global --unsafe-perm --no-audit --no-fund /usr/local/lib/llnode/llnode-3.2.0.tgz \
+ && rm -rf /usr/local/lib/llnode \
  && which -a llnode \
  \
  # Clean up


### PR DESCRIPTION
Update how `llnode` is installed due to [npm CLI changes](https://github.com/npm/cli/pull/4428/files#diff-5d468c4e7490359f170b4de0527ea12477a429e664f7946bf311f5183ac89f5d)