### PR TITLE
[FIX] Pin `jupyterlab-desktop` version

### DIFF
--- a/dev/dockerfiles/devel/main.Dockerfile
+++ b/dev/dockerfiles/devel/main.Dockerfile
@@ -317,7 +317,7 @@ RUN --mount=type=cache,target=/var/lib/apt \
  \
  && apt update \
  && apt install --no-install-recommends -y \
-    jq entr nano sudo bash-completion \
+    jq entr ssh vim nano sudo bash-completion \
     # X11 dependencies
     libxi-dev libxrandr-dev libxinerama-dev libxcursor-dev \
     # node-canvas dependencies

--- a/dev/dockerfiles/devel/notebook.Dockerfile
+++ b/dev/dockerfiles/devel/notebook.Dockerfile
@@ -13,7 +13,7 @@ ADD --chown=rapids:rapids \
     /opt/rapids/.local/share/jupyter/kernels/javascript/logo-64x64.png
 
 ADD --chown=root:root \
-    https://github.com/jupyterlab/jupyterlab-desktop/releases/latest/download/JupyterLab-Setup-Debian.deb \
+    https://github.com/jupyterlab/jupyterlab-desktop/releases/download/v3.3.2-1/JupyterLab-Setup-Debian.deb \
     /tmp/JupyterLab-Setup-Debian.deb
 
 USER root
@@ -35,7 +35,7 @@ if __name__ == \"__main__\":\n\
     \"--hide-undefined\",\n\
     \"{connection_file}\",\n\
     \"--protocol=5.0\",\n\
-    \"--session-working-dir=/opt/rapids\"\n\
+    \"--session-working-dir=/opt/rapids/node\"\n\
   ],\n\
   \"name\": \"javascript\",\n\
   \"language\": \"javascript\",\n\

--- a/dev/dockerfiles/runtime/notebook.Dockerfile
+++ b/dev/dockerfiles/runtime/notebook.Dockerfile
@@ -15,7 +15,7 @@ ADD --chown=node:node \
     /home/node/.local/share/jupyter/kernels/javascript/logo-64x64.png
 
 ADD --chown=root:root \
-    https://github.com/jupyterlab/jupyterlab-desktop/releases/latest/download/JupyterLab-Setup-Debian.deb \
+    https://github.com/jupyterlab/jupyterlab-desktop/releases/download/v3.3.2-1/JupyterLab-Setup-Debian.deb \
     /tmp/JupyterLab-Setup-Debian.deb
 
 USER root


### PR DESCRIPTION
The latest release of `jupyterlab-desktop` seems to fail with the following unskippable dialog: 
![image](https://user-images.githubusercontent.com/178183/165167026-a695faab-2c20-46f4-8887-1a85eefbf77c.png)

Pinning to `v3.3.2` seems to work, even though it now just shows this dialog on startup: 
![image](https://user-images.githubusercontent.com/178183/165167201-974906c5-44ae-4e59-b9d7-95263e786906.png)

Doesn't seem like there's a way to configure it to not check for updates on startup, so this'll have to be good enough for now.