### PR TITLE
[FIX] add latest CUDA apt key

### DIFF
--- a/dev/dockerfiles/devel/main.Dockerfile
+++ b/dev/dockerfiles/devel/main.Dockerfile
@@ -63,6 +63,11 @@ RUN --mount=type=cache,target=/var/lib/apt \
  \
  # Install compilers
     export DEBIAN_FRONTEND=noninteractive \
+ # Workaround for https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
+ && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/$( \
+    . /etc/os-release; echo $NAME$VERSION_ID | tr -d '.' | tr '[:upper:]' '[:lower:]' \
+ )/$(uname -p)/3bf863cc.pub \
+ \
  && apt update \
  && apt install --no-install-recommends -y \
     gpg wget software-properties-common \

--- a/dev/dockerfiles/runtime/base.Dockerfile
+++ b/dev/dockerfiles/runtime/base.Dockerfile
@@ -39,6 +39,11 @@ ADD --chown=root:root https://gitlab.com/nvidia/container-images/opengl/-/raw/51
 
 # Install gcc-9 toolchain
 RUN export DEBIAN_FRONTEND=noninteractive \
+ # Workaround for https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
+ && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/$( \
+    . /etc/os-release; echo $NAME$VERSION_ID | tr -d '.' | tr '[:upper:]' '[:lower:]' \
+ )/$(uname -p)/3bf863cc.pub \
+ \
  && apt update \
  && apt install --no-install-recommends -y \
     software-properties-common \


### PR DESCRIPTION
Fix container builds in light of [the recent apt key rotation](https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772).