### PR TITLE
Link createLonLatToCartesian in `@rapidsai/cuspatial`

### DIFF
--- a/modules/cuspatial/src/addon.cpp
+++ b/modules/cuspatial/src/addon.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modules/cuspatial/src/addon.cpp
+++ b/modules/cuspatial/src/addon.cpp
@@ -21,19 +21,20 @@ struct rapidsai_cuspatial : public nv::EnvLocalAddon, public Napi::Addon<rapidsa
   rapidsai_cuspatial(Napi::Env const& env, Napi::Object exports) : nv::EnvLocalAddon(env, exports) {
     DefineAddon(
       exports,
-      {
-        InstanceMethod("init", &rapidsai_cuspatial::InitAddon),
-        InstanceValue("_cpp_exports", _cpp_exports.Value()),
-        InstanceMethod<&rapidsai_cuspatial::create_quadtree>("createQuadtree"),
-        InstanceMethod<&rapidsai_cuspatial::quadtree_bounding_box_intersections>(
-          "findQuadtreeAndBoundingBoxIntersections"),
-        InstanceMethod<&rapidsai_cuspatial::find_points_in_polygons>("findPointsInPolygons"),
-        InstanceMethod<&rapidsai_cuspatial::find_polyline_nearest_to_each_point>(
-          "findPolylineNearestToEachPoint"),
-        InstanceMethod<&rapidsai_cuspatial::compute_polygon_bounding_boxes>(
-          "computePolygonBoundingBoxes"),
-        InstanceMethod<&rapidsai_cuspatial::compute_polyline_bounding_boxes>(
-          "computePolylineBoundingBoxes"),
+      {InstanceMethod("init", &rapidsai_cuspatial::InitAddon),
+       InstanceValue("_cpp_exports", _cpp_exports.Value()),
+       InstanceMethod<&rapidsai_cuspatial::create_quadtree>("createQuadtree"),
+       InstanceMethod<&rapidsai_cuspatial::quadtree_bounding_box_intersections>(
+         "findQuadtreeAndBoundingBoxIntersections"),
+       InstanceMethod<&rapidsai_cuspatial::find_points_in_polygons>("findPointsInPolygons"),
+       InstanceMethod<&rapidsai_cuspatial::find_polyline_nearest_to_each_point>(
+         "findPolylineNearestToEachPoint"),
+       InstanceMethod<&rapidsai_cuspatial::compute_polygon_bounding_boxes>(
+         "computePolygonBoundingBoxes"),
+       InstanceMethod<&rapidsai_cuspatial::compute_polyline_bounding_boxes>(
+         "computePolylineBoundingBoxes"),
+       InstanceMethod<&rapidsai_cuspatial::lonlat_to_cartesian>("lonLatToCartesian")
+
       });
   }
 
@@ -53,6 +54,9 @@ struct rapidsai_cuspatial : public nv::EnvLocalAddon, public Napi::Addon<rapidsa
   }
   Napi::Value compute_polyline_bounding_boxes(Napi::CallbackInfo const& info) {
     return nv::compute_polyline_bounding_boxes(info);
+  }
+  Napi::Value lonlat_to_cartesian(Napi::CallbackInfo const& info) {
+    return nv::lonlat_to_cartesian(info);
   }
 };
 

--- a/modules/cuspatial/src/addon.ts
+++ b/modules/cuspatial/src/addon.ts
@@ -26,6 +26,7 @@ export const {
   computePolylineBoundingBoxes,
   findPointsInPolygons,
   findPolylineNearestToEachPoint,
+  lonLatToCartesian,
   _cpp_exports,
 } = require('bindings')('rapidsai_cuspatial.node').init(CORE, CUDA, RMM, CUDF) as
     typeof import('./node_cuspatial');

--- a/modules/cuspatial/src/geometry.cpp
+++ b/modules/cuspatial/src/geometry.cpp
@@ -26,8 +26,6 @@
 
 #include <nv_node/utilities/args.hpp>
 
-#include <iostream>
-
 namespace nv {
 
 Napi::Value compute_polygon_bounding_boxes(CallbackArgs const& args) {

--- a/modules/cuspatial/src/geometry.cpp
+++ b/modules/cuspatial/src/geometry.cpp
@@ -19,11 +19,14 @@
 
 #include <node_rmm/utilities/napi_to_cpp.hpp>
 
+#include <cuspatial/coordinate_transform.hpp>
 #include <cuspatial/error.hpp>
 #include <cuspatial/polygon_bounding_box.hpp>
 #include <cuspatial/polyline_bounding_box.hpp>
 
 #include <nv_node/utilities/args.hpp>
+
+#include <iostream>
 
 namespace nv {
 
@@ -70,6 +73,23 @@ Napi::Value compute_polyline_bounding_boxes(CallbackArgs const& args) {
   names.Set(3u, "y_max");
   output.Set("names", names);
   output.Set("table", Table::New(args.Env(), std::move(result)));
+  return output;
+}
+
+Napi::Value lonlat_to_cartesian(CallbackArgs const& args) {
+  double origin_lon                   = args[0];
+  double origin_lat                   = args[1];
+  Column::wrapper_t lons_column       = args[2];
+  Column::wrapper_t lats_column       = args[3];
+  rmm::mr::device_memory_resource* mr = args[4];
+  auto result                         = [&]() {
+    try {
+      return cuspatial::lonlat_to_cartesian(origin_lon, origin_lat, *lons_column, *lats_column, mr);
+    } catch (std::exception const& e) { throw Napi::Error::New(args.Env(), e.what()); }
+  }();
+  auto output = Napi::Object::New(args.Env());
+  output.Set("x", Column::New(args.Env(), std::move(result.first)));
+  output.Set("y", Column::New(args.Env(), std::move(result.second)));
   return output;
 }
 

--- a/modules/cuspatial/src/geometry.cpp
+++ b/modules/cuspatial/src/geometry.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modules/cuspatial/src/index.ts
+++ b/modules/cuspatial/src/index.ts
@@ -14,3 +14,4 @@
 
 export * from './geometry';
 export * from './quadtree';
+export * from './spatial';

--- a/modules/cuspatial/src/node_cuspatial.ts
+++ b/modules/cuspatial/src/node_cuspatial.ts
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Column, FloatingPoint, Int32, Table, Uint32} from '@rapidsai/cudf';
+import {Column, FloatingPoint, Int32, Series, Table, Uint32} from '@rapidsai/cudf';
 import {MemoryResource} from '@rapidsai/rmm';
 
 /** @ignore */
 export declare const _cpp_exports: any;
+
+export type SeriesPair<T extends FloatingPoint> = {
+  x: Series<T>; y: Series<T>;
+}
 
 export declare function createQuadtree<T extends FloatingPoint>(xs: Column<T>,
                                                                 ys: Column<T>,
@@ -78,3 +82,10 @@ export declare function findPolylineNearestToEachPoint<T extends FloatingPoint>(
   polylinePointsY: Column<T>,
   memoryResource
   ?: MemoryResource): {table: Table, names: ['point_index', 'polyline_index', 'distance']};
+
+export declare function lonLatToCartesian<T extends FloatingPoint>(
+  origin_lon: number,
+  origin_lat: number,
+  lats: Series,
+  lons: Series,
+  memoryResource?: MemoryResource): {x: Series, y: Series};

--- a/modules/cuspatial/src/node_cuspatial.ts
+++ b/modules/cuspatial/src/node_cuspatial.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Column, FloatingPoint, Int32, Series, Table, Uint32} from '@rapidsai/cudf';
+import {Column, FloatingPoint, Int32, Table, Uint32} from '@rapidsai/cudf';
 import {MemoryResource} from '@rapidsai/rmm';
 
 /** @ignore */
@@ -79,8 +79,9 @@ export declare function findPolylineNearestToEachPoint<T extends FloatingPoint>(
   memoryResource
   ?: MemoryResource): {table: Table, names: ['point_index', 'polyline_index', 'distance']};
 
-export declare function lonLatToCartesian<T extends FloatingPoint>(origin_lon: number,
-                                          origin_lat: number,
-                                          lats: Column<T>,
-                                          lons: Column<T>,
-                                          memoryResource?: MemoryResource): {x: Column<T>, y: Column<T>};
+export declare function lonLatToCartesian<T extends FloatingPoint>(
+  origin_lon: number,
+  origin_lat: number,
+  lats: Column<T>,
+  lons: Column<T>,
+  memoryResource?: MemoryResource): {x: Column<T>, y: Column<T>};

--- a/modules/cuspatial/src/node_cuspatial.ts
+++ b/modules/cuspatial/src/node_cuspatial.ts
@@ -18,10 +18,6 @@ import {MemoryResource} from '@rapidsai/rmm';
 /** @ignore */
 export declare const _cpp_exports: any;
 
-export type SeriesPair<T extends FloatingPoint> = {
-  x: Series<T>; y: Series<T>;
-}
-
 export declare function createQuadtree<T extends FloatingPoint>(xs: Column<T>,
                                                                 ys: Column<T>,
                                                                 xMin: number,
@@ -83,9 +79,8 @@ export declare function findPolylineNearestToEachPoint<T extends FloatingPoint>(
   memoryResource
   ?: MemoryResource): {table: Table, names: ['point_index', 'polyline_index', 'distance']};
 
-export declare function lonLatToCartesian<T extends FloatingPoint>(
-  origin_lon: number,
-  origin_lat: number,
-  lats: Series,
-  lons: Series,
-  memoryResource?: MemoryResource): {x: Series, y: Series};
+export declare function lonLatToCartesian(origin_lon: number,
+                                          origin_lat: number,
+                                          lats: Series,
+                                          lons: Series,
+                                          memoryResource?: MemoryResource): {x: Series, y: Series};

--- a/modules/cuspatial/src/node_cuspatial.ts
+++ b/modules/cuspatial/src/node_cuspatial.ts
@@ -79,8 +79,8 @@ export declare function findPolylineNearestToEachPoint<T extends FloatingPoint>(
   memoryResource
   ?: MemoryResource): {table: Table, names: ['point_index', 'polyline_index', 'distance']};
 
-export declare function lonLatToCartesian(origin_lon: number,
+export declare function lonLatToCartesian<T extends FloatingPoint>(origin_lon: number,
                                           origin_lat: number,
-                                          lats: Series,
-                                          lons: Series,
-                                          memoryResource?: MemoryResource): {x: Series, y: Series};
+                                          lats: Column<T>,
+                                          lons: Column<T>,
+                                          memoryResource?: MemoryResource): {x: Column<T>, y: Column<T>};

--- a/modules/cuspatial/src/node_cuspatial/geometry.hpp
+++ b/modules/cuspatial/src/node_cuspatial/geometry.hpp
@@ -34,4 +34,11 @@ Napi::Value compute_polygon_bounding_boxes(CallbackArgs const& args);
  */
 Napi::Value compute_polyline_bounding_boxes(CallbackArgs const& args);
 
+/**
+ * @brief Convert lon/lat coordinate columns into cartesian coordinates.
+ *
+ * @param args CallbackArgs JavaScript arguments list.
+ */
+Napi::Value lonlat_to_cartesian(CallbackArgs const& args);
+
 }  // namespace nv

--- a/modules/cuspatial/src/spatial.ts
+++ b/modules/cuspatial/src/spatial.ts
@@ -18,16 +18,18 @@ import {
   Series,
 } from '@rapidsai/cudf';
 import {makePoints} from '@rapidsai/cuspatial';
+import {MemoryResource} from '@rapidsai/rmm';
 
 import {
   lonLatToCartesian,
 } from './addon';
 
-export function convertLonLatToCartesian<T extends FloatingPoint>(
-  centerX: number, centerY: number, lonPoints: Series<T>, latPoints: Series<T>) {
-  const result =
-    lonLatToCartesian(centerX, centerY, lonPoints._col as Column<T>, latPoints._col as Column<T>);
-  const x = Series.new(result.x);
-  const y = Series.new(result.y);
-  return makePoints(x, y);
+export function convertLonLatToCartesian<T extends FloatingPoint>(centerX: number,
+                                                                  centerY: number,
+                                                                  lonPoints: Series<T>,
+                                                                  latPoints: Series<T>,
+                                                                  memoryResource?: MemoryResource) {
+  const {x, y} = lonLatToCartesian(
+    centerX, centerY, lonPoints._col as Column<T>, latPoints._col as Column<T>, memoryResource);
+  return makePoints(Series.new(x), Series.new(y));
 }

--- a/modules/cuspatial/src/spatial.ts
+++ b/modules/cuspatial/src/spatial.ts
@@ -18,16 +18,16 @@ import {
   Series,
 } from '@rapidsai/cudf';
 import {makePoints} from '@rapidsai/cuspatial';
-import {Points} from '@rapidsai/cuspatial/geometry';
 
 import {
   lonLatToCartesian,
 } from './addon';
 
 export function convertLonLatToCartesian<T extends FloatingPoint>(
-  centerX: number, centerY: number, lonPoints: Series<T>, latPoints: Series<T>): Points<T> {
-  const result = lonLatToCartesian(centerX, centerY, lonPoints._col, latPoints._col);
-  const x      = Series.new(result.x);
-  const y      = Series.new(result.y);
+  centerX: number, centerY: number, lonPoints: Series<T>, latPoints: Series<T>) {
+  const result =
+    lonLatToCartesian(centerX, centerY, lonPoints._col as Column<T>, latPoints._col as Column<T>);
+  const x = Series.new(result.x);
+  const y = Series.new(result.y);
   return makePoints(x, y);
 }

--- a/modules/cuspatial/src/spatial.ts
+++ b/modules/cuspatial/src/spatial.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, NVIDIA CORPORATION.
+// Copyright (c) 2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,18 +17,17 @@ import {
   FloatingPoint,
   Series,
 } from '@rapidsai/cudf';
+import {makePoints} from '@rapidsai/cuspatial';
+import {Points} from '@rapidsai/cuspatial/geometry';
 
 import {
   lonLatToCartesian,
 } from './addon';
-import {
-  SeriesPair,
-} from './node_cuspatial';
 
 export function convertLonLatToCartesian<T extends FloatingPoint>(
-  centerX: number, centerY: number, lonPoints: Column<T>, latPoints: Column<T>): SeriesPair<T> {
+  centerX: number, centerY: number, lonPoints: Column<T>, latPoints: Column<T>): Points<T> {
   const result = lonLatToCartesian(centerX, centerY, lonPoints, latPoints);
   const x      = Series.new(result.x);
   const y      = Series.new(result.y);
-  return {x: x, y: y};
+  return makePoints(x, y);
 }

--- a/modules/cuspatial/src/spatial.ts
+++ b/modules/cuspatial/src/spatial.ts
@@ -25,8 +25,8 @@ import {
 } from './addon';
 
 export function convertLonLatToCartesian<T extends FloatingPoint>(
-  centerX: number, centerY: number, lonPoints: Column<T>, latPoints: Column<T>): Points<T> {
-  const result = lonLatToCartesian(centerX, centerY, lonPoints, latPoints);
+  centerX: number, centerY: number, lonPoints: Series<T>, latPoints: Series<T>): Points<T> {
+  const result = lonLatToCartesian(centerX, centerY, lonPoints._col, latPoints._col);
   const x      = Series.new(result.x);
   const y      = Series.new(result.y);
   return makePoints(x, y);

--- a/modules/cuspatial/src/spatial.ts
+++ b/modules/cuspatial/src/spatial.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2021-2022, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  Column,
+  FloatingPoint,
+  Series,
+} from '@rapidsai/cudf';
+
+import {
+  lonLatToCartesian,
+} from './addon';
+import {
+  SeriesPair,
+} from './node_cuspatial';
+
+export function convertLonLatToCartesian<T extends FloatingPoint>(
+  centerX: number, centerY: number, lonPoints: Column<T>, latPoints: Column<T>): SeriesPair<T> {
+  const result = lonLatToCartesian(centerX, centerY, lonPoints, latPoints);
+  const x      = Series.new(result.x);
+  const y      = Series.new(result.y);
+  return {x: x, y: y};
+}

--- a/modules/cuspatial/test/quadtree-tests.ts
+++ b/modules/cuspatial/test/quadtree-tests.ts
@@ -76,6 +76,7 @@ describe('Quadtree', () => {
     });
 
     const polygonAndPointIdxs = quadtree.pointInPolygon(testPolygons());
+
     expect(polygonAndPointIdxs.get('polygon_index').data.toArray())
       .toEqualTypedArray(
         new Uint32Array([3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 3]));

--- a/modules/cuspatial/test/quadtree-tests.ts
+++ b/modules/cuspatial/test/quadtree-tests.ts
@@ -76,7 +76,6 @@ describe('Quadtree', () => {
     });
 
     const polygonAndPointIdxs = quadtree.pointInPolygon(testPolygons());
-
     expect(polygonAndPointIdxs.get('polygon_index').data.toArray())
       .toEqualTypedArray(
         new Uint32Array([3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 3]));

--- a/modules/cuspatial/test/spatial-tests.ts
+++ b/modules/cuspatial/test/spatial-tests.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2021, NVIDIA CORPORATION.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import '@rapidsai/cudf/test/jest-extensions';
+
+import {setDefaultAllocator} from '@rapidsai/cuda';
+import {Series} from '@rapidsai/cudf';
+import {convertLonLatToCartesian} from '@rapidsai/cuspatial';
+import {DeviceBuffer} from '@rapidsai/rmm';
+
+setDefaultAllocator((byteLength: number) => new DeviceBuffer(byteLength));
+
+describe('Spatial', () => {
+  test(`convertLonLatToCartesian`, () => {
+    const seriesX = Series.new([-120.0, -120.0]);
+    const seriesY = Series.new([48.0, 49.0]);
+    const result  = convertLonLatToCartesian(1.0, 1.0, seriesX._col, seriesY._col);
+
+    expect(result.y.toArray()).toMatchObject({'0': -5222.222222222223, '1': -5333.333333333334});
+    expect(result.x.toArray()).toMatchObject({'0': 12233.92375289575, '1': 12184.804692381627});
+  });
+});

--- a/modules/cuspatial/test/spatial-tests.ts
+++ b/modules/cuspatial/test/spatial-tests.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION.
+// Copyright (c) 2022, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,9 @@ describe('Spatial', () => {
     const seriesY = Series.new([48.0, 49.0]);
     const result  = convertLonLatToCartesian(1.0, 1.0, seriesX._col, seriesY._col);
 
-    expect(result.y.toArray()).toMatchObject({'0': -5222.222222222223, '1': -5333.333333333334});
-    expect(result.x.toArray()).toMatchObject({'0': 12233.92375289575, '1': 12184.804692381627});
+    expect(result.getChild('y').toArray())
+      .toMatchObject({'0': -5222.222222222223, '1': -5333.333333333334});
+    expect(result.getChild('x').toArray())
+      .toMatchObject({'0': 12233.92375289575, '1': 12184.804692381627});
   });
 });

--- a/modules/cuspatial/test/spatial-tests.ts
+++ b/modules/cuspatial/test/spatial-tests.ts
@@ -25,7 +25,7 @@ describe('Spatial', () => {
   test(`convertLonLatToCartesian`, () => {
     const seriesX = Series.new([-120.0, -120.0]);
     const seriesY = Series.new([48.0, 49.0]);
-    const result  = convertLonLatToCartesian(1.0, 1.0, seriesX._col, seriesY._col);
+    const result  = convertLonLatToCartesian(1.0, 1.0, seriesX, seriesY);
 
     expect(result.getChild('y').toArray())
       .toMatchObject({'0': -5222.222222222223, '1': -5333.333333333334});


### PR DESCRIPTION
This PR makes the lon_lat_to_cartesian function in cuspatial available in `node-rapids`, including one basic test.

Closes #441