### PR TITLE
Use ARC V2 self-hosted runners for CPU jobs

### DIFF
--- a/.github/workflows/build-and-push-image-ssh.yml
+++ b/.github/workflows/build-and-push-image-ssh.yml
@@ -58,7 +58,7 @@ on:
 
 jobs:
   build-and-publish-image:
-    runs-on: [self-hosted, linux, amd64, cpu4]
+    runs-on: linux-amd64-cpu4
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -49,7 +49,7 @@ on:
 
 jobs:
   build-and-publish-image:
-    runs-on: [self-hosted, linux, amd64, cpu4]
+    runs-on: linux-amd64-cpu4
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/main.pr.yml
+++ b/.github/workflows/main.pr.yml
@@ -9,7 +9,7 @@ jobs:
   build-pull-request:
     name: Build pull request
     # runs-on: ubuntu-20.04
-    runs-on: [self-hosted, linux, amd64, cpu4]
+    runs-on: linux-amd64-cpu4
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
   extract-and-publish-packages:
     name: Extract libs and publish release
-    runs-on: [self-hosted, linux, amd64, cpu16]
+    runs-on: linux-amd64-cpu16
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
This PR is updating the runner labels to use ARC V2 self-hosted runners for CPU jobs only. This is needed to resolve the auto-scalling issues.